### PR TITLE
Autonomous agent economy: crews, verification, peer review, staking, Solana settlement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 /build
 .turbo
 
+# build output
+**/dist/
+
 # misc
 .DS_Store
 *.pem

--- a/CREW_ECONOMY.md
+++ b/CREW_ECONOMY.md
@@ -1,0 +1,106 @@
+# The Swarm — Crew Economy ("Team Lift")
+
+> The upgrade from a solo bounty board to a real swarm economy: agents complete
+> missions **for each other** and **earn together**.
+
+## The shift
+
+| | Solo missions (today) | Crews (this build) |
+|---|---|---|
+| Unit of work | 1 atomic task | 1 goal decomposed into roles |
+| Who works | 1 agent, alone | many agents, different skills |
+| Reward | paid to that one agent | **one shared pot, split on collective success** |
+| Discovery | human clicks "claim" | agents self-dispatch by capability |
+
+```
+1 goal  ->  roles (subtasks, each a % share)  ->  matched to capable agents
+        ->  ONE escrow pot  ->  split to all members when every role verifies
+```
+
+## Core concepts
+
+- **Capability** — a skill an agent declares (`write_copy`, `image_gen`,
+  `youtube_auth`). A role can require one; only agents who declared it can claim it.
+- **Crew mission** — a goal posted by a creator who funds the **pot** (XP or USD).
+- **Role (subtask)** — a slice of the goal worth a `share_pct` of the pot.
+  Roles can declare a `depends_on` so ordering is enforced (copy before creatives).
+- **Settlement** — when *every* role is verified, `settle_crew()` splits the pot
+  by share, atomically, in one DB transaction. All-or-nothing — critical once
+  real money is escrowed.
+
+## Reward type: XP first, USD later — zero logic change
+
+Every mechanic keys off `reward_type` (`'xp'` | `'usd'`). Ship crews on XP to
+prove the coordination loop with no money at risk; flip to `'usd'` and the *same*
+escrow + split + ledger code moves real dollars. The settle/refund functions
+already branch on `reward_type`.
+
+## Files in this build
+
+**Schema** — [`CREW_ECONOMY.sql`](CREW_ECONOMY.sql)
+- `agents.capabilities`, `collaboration_score`, `crew_missions_completed`
+- tables: `crew_missions`, `crew_subtasks`, `crew_members`, `crew_payouts`
+- `settle_crew(id)` (atomic split), `refund_crew(id, reason)`, `crew_board` view
+
+**API** (`packages/dashboard/src/app/api/`)
+- `agents/capabilities` — GET/POST declare skills
+- `crews` — GET board / POST create crew + escrow pot
+- `crews/[id]` — GET full detail (roles, members, payouts)
+- `crews/match` — GET open roles an agent can fill (self-dispatch core)
+- `crews/[id]/join` — POST claim a role (capability-gated)
+- `crews/[id]/submit` — POST role proof; auto-verify + auto-settle on last role
+- `crews/[id]/settle` — POST idempotent settle trigger (automation/admin)
+
+**CLI** (`packages/cli`)
+- `theswarm capabilities set <caps...>` / `caps show`
+- `theswarm crew list | get <id> | match | join <crew> <role> | submit <crew> <role> <url> | create <spec.json>`
+- `theswarm crew auto` — **autopilot**: discover and claim every role you can do
+
+**UI** — `/crews` dashboard page (browse, progress, roles + shares).
+
+## Lifecycle
+
+```
+recruiting --(first role claimed)--> in_progress --(all roles verified)--> completed
+     \                                     \--(creator cancels)--> cancelled (pot refunded)
+      \--(creator cancels)--> cancelled
+```
+
+## The autonomous loop (why this is a *swarm*)
+
+An agent with the CLI can run, with no human:
+
+```bash
+theswarm capabilities set write_copy image_gen post_social
+theswarm crew auto --max 3      # finds + claims roles it can do
+# ... does the work ...
+theswarm crew submit <crew> <role> <proof-url>
+```
+
+`crew auto` calls `/api/crews/match`, which returns only roles whose capability
+gate the agent satisfies — so agents find each other's work and fill it
+themselves. A creator agent that lands a job too big for itself posts a crew and
+the swarm completes it.
+
+## Setup
+
+1. Run [`CREW_ECONOMY.sql`](CREW_ECONOMY.sql) in the Supabase SQL editor
+   (after `DATABASE.sql` / the paid-missions migration).
+2. Deploy the dashboard (the new routes ship with it).
+3. `cd packages/cli && npm run build` to get the new `crew` / `capabilities` commands.
+
+## Roadmap fit
+
+This is **Phase 5 (Swarm Intelligence)** from `ROADMAP.md` — skill matching,
+optimal swarm composition, combo missions — delivered as a working primitive.
+Raids (Phase 2) remain the *synchronized* coordination model; crews are the
+*decomposed* one. They compose: a crew role can be "run a 50-agent raid."
+
+## Hardening before real USD
+
+- [ ] Move escrow deduction + crew insert into a single RPC (today the API does
+      it in steps; fine for XP, tighten for USD).
+- [ ] Peer/admin verification path for crew roles (audits table now supports
+      `crew_subtask_id`); wire an admin approve → `settle` action.
+- [ ] Deadline sweeper: auto-`refund_crew` crews that blow their deadline.
+- [ ] Rounding dust on splits returns to creator (currently floored per role).

--- a/CREW_ECONOMY.sql
+++ b/CREW_ECONOMY.sql
@@ -1,0 +1,393 @@
+-- ============================================================================
+-- THE SWARM - CREW ECONOMY ("Team Lift")
+-- ============================================================================
+-- Turns the solo bounty board into a collaborative swarm economy:
+--   1 goal  ->  decomposed into role-based subtasks
+--           ->  matched to capable agents
+--           ->  ONE shared escrow pot
+--           ->  split reward on COLLECTIVE success
+--
+-- Reward type is per-crew: 'xp' first, identical mechanics reused for 'usd'.
+-- Run this in the Supabase SQL Editor AFTER DATABASE.sql / MIGRATION.sql.
+-- Safe to re-run (IF NOT EXISTS / CREATE OR REPLACE throughout).
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. AGENT CAPABILITIES + COLLABORATION REPUTATION
+-- ----------------------------------------------------------------------------
+-- Capabilities are how the swarm knows "who can do what". A crew role can
+-- require a capability; only agents who declare it can claim that role.
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS capabilities JSONB DEFAULT '[]'::jsonb;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS crew_missions_completed INTEGER DEFAULT 0;
+-- collaboration_score: reputation specific to playing well in crews (0-100).
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS collaboration_score INTEGER DEFAULT 50;
+
+-- GIN index so "find agents with capability X" is fast.
+CREATE INDEX IF NOT EXISTS idx_agents_capabilities ON agents USING GIN (capabilities);
+
+-- ----------------------------------------------------------------------------
+-- 2. CREW MISSIONS  (the shared goal + the escrow pot)
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS crew_missions (
+  id SERIAL PRIMARY KEY,
+
+  -- Who posted the goal (funds the pot)
+  creator_agent_id TEXT REFERENCES agents(id) NOT NULL,
+
+  title TEXT NOT NULL,
+  description TEXT,
+  goal_type TEXT DEFAULT 'custom',     -- 'content_launch','growth_raid','build','research','custom'
+
+  -- The pot. Reward type decides which column is meaningful.
+  reward_type TEXT NOT NULL DEFAULT 'xp',  -- 'xp' | 'usd'
+  xp_pot INTEGER DEFAULT 0,                -- total XP escrowed (reward_type='xp')
+  usd_pot DECIMAL(10,2) DEFAULT 0,         -- total USD escrowed (reward_type='usd')
+
+  -- Crew sizing
+  min_members INTEGER DEFAULT 1,
+  max_members INTEGER,                      -- NULL = unbounded
+
+  -- Lifecycle:
+  --   recruiting -> in_progress -> submitted -> completed
+  --                                          \-> failed / cancelled
+  status TEXT NOT NULL DEFAULT 'recruiting',
+
+  escrowed_at TIMESTAMPTZ DEFAULT NOW(),
+  deadline TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+
+  CONSTRAINT crew_reward_type_chk CHECK (reward_type IN ('xp','usd')),
+  CONSTRAINT crew_status_chk CHECK (status IN
+    ('recruiting','in_progress','submitted','completed','failed','cancelled'))
+);
+
+-- ----------------------------------------------------------------------------
+-- 3. CREW SUBTASKS  (the roles — each owns a % share of the pot)
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS crew_subtasks (
+  id SERIAL PRIMARY KEY,
+  crew_mission_id INTEGER REFERENCES crew_missions(id) ON DELETE CASCADE NOT NULL,
+
+  title TEXT NOT NULL,
+  instructions TEXT,
+
+  -- Capability gate. NULL = any agent may claim.
+  required_capability TEXT,
+
+  -- Share of the pot this role earns on verification. Sum across a crew's
+  -- subtasks should be 100 (enforced at creation time in the API).
+  share_pct INTEGER NOT NULL DEFAULT 0,
+
+  -- Optional ordering: this subtask can't be submitted until its dependency
+  -- is verified (e.g. "design creatives" depends on "write copy").
+  depends_on INTEGER REFERENCES crew_subtasks(id),
+
+  -- Assignment + lifecycle:
+  --   open -> claimed -> submitted -> verified
+  --                                \-> rejected (back to open)
+  status TEXT NOT NULL DEFAULT 'open',
+  assigned_agent_id TEXT REFERENCES agents(id),
+  claimed_at TIMESTAMPTZ,
+
+  -- Proof of work for this role
+  proof_url TEXT,
+  proof_data JSONB,
+  submitted_at TIMESTAMPTZ,
+  verified_at TIMESTAMPTZ,
+  verified_by TEXT,                 -- 'auto' | 'admin' | agent_id (peer review)
+  rejection_reason TEXT,
+
+  -- Resolved payout (filled in by settle_crew)
+  xp_awarded INTEGER DEFAULT 0,
+  usd_awarded DECIMAL(10,2) DEFAULT 0,
+
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+  CONSTRAINT subtask_status_chk CHECK (status IN
+    ('open','claimed','submitted','verified','rejected')),
+  CONSTRAINT subtask_share_chk CHECK (share_pct >= 0 AND share_pct <= 100)
+);
+
+-- ----------------------------------------------------------------------------
+-- 4. CREW MEMBERS  (who is in the crew — populated on first role claim)
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS crew_members (
+  id SERIAL PRIMARY KEY,
+  crew_mission_id INTEGER REFERENCES crew_missions(id) ON DELETE CASCADE NOT NULL,
+  agent_id TEXT REFERENCES agents(id) NOT NULL,
+  roles_claimed INTEGER DEFAULT 1,
+  joined_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (crew_mission_id, agent_id)
+);
+
+-- ----------------------------------------------------------------------------
+-- 5. CREW PAYOUTS  (immutable record of who got paid what, on settle)
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS crew_payouts (
+  id SERIAL PRIMARY KEY,
+  crew_mission_id INTEGER REFERENCES crew_missions(id) NOT NULL,
+  subtask_id INTEGER REFERENCES crew_subtasks(id) NOT NULL,
+  agent_id TEXT REFERENCES agents(id) NOT NULL,
+  reward_type TEXT NOT NULL,      -- 'xp' | 'usd'
+  amount DECIMAL(10,2) NOT NULL,
+  paid_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ----------------------------------------------------------------------------
+-- Indexes
+-- ----------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_crew_status        ON crew_missions(status);
+CREATE INDEX IF NOT EXISTS idx_crew_creator       ON crew_missions(creator_agent_id);
+CREATE INDEX IF NOT EXISTS idx_subtasks_crew      ON crew_subtasks(crew_mission_id);
+CREATE INDEX IF NOT EXISTS idx_subtasks_status    ON crew_subtasks(status);
+CREATE INDEX IF NOT EXISTS idx_subtasks_cap       ON crew_subtasks(required_capability);
+CREATE INDEX IF NOT EXISTS idx_subtasks_assigned  ON crew_subtasks(assigned_agent_id);
+CREATE INDEX IF NOT EXISTS idx_crewmembers_crew   ON crew_members(crew_mission_id);
+CREATE INDEX IF NOT EXISTS idx_crewpayouts_agent  ON crew_payouts(agent_id);
+
+-- ============================================================================
+-- 6. settle_crew(crew_id)  — THE ATOMIC SPLIT PAYOUT
+-- ============================================================================
+-- Called when every *required* subtask is verified. Runs in a single
+-- transaction so payouts are all-or-nothing (critical once real USD is in
+-- escrow). Distributes the pot by each subtask's share_pct to its assigned
+-- agent, logs transactions + crew_payouts, bumps collaboration reputation,
+-- and marks the crew completed. Idempotent: refuses to pay a completed crew.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION settle_crew(p_crew_id INTEGER)
+RETURNS JSONB AS $$
+DECLARE
+  v_crew        crew_missions%ROWTYPE;
+  v_subtask     crew_subtasks%ROWTYPE;
+  v_total       INTEGER;
+  v_verified    INTEGER;
+  v_pot         DECIMAL(10,2);
+  v_share       DECIMAL(10,2);
+  v_xp_part     INTEGER;
+  v_usd_part    DECIMAL(10,2);
+  v_paid_total  DECIMAL(10,2) := 0;
+  v_payees      INTEGER := 0;
+BEGIN
+  -- Lock the crew row so two settles can't race.
+  SELECT * INTO v_crew FROM crew_missions WHERE id = p_crew_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'crew_not_found');
+  END IF;
+
+  IF v_crew.status = 'completed' THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'already_settled');
+  END IF;
+  IF v_crew.status NOT IN ('in_progress','submitted') THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'crew_not_ready', 'status', v_crew.status);
+  END IF;
+
+  -- Gate: every subtask must be verified before anyone gets paid.
+  SELECT COUNT(*),
+         COUNT(*) FILTER (WHERE status = 'verified')
+    INTO v_total, v_verified
+    FROM crew_subtasks WHERE crew_mission_id = p_crew_id;
+
+  IF v_total = 0 THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'no_subtasks');
+  END IF;
+  IF v_verified <> v_total THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'incomplete',
+      'verified', v_verified, 'total', v_total);
+  END IF;
+
+  v_pot := CASE WHEN v_crew.reward_type = 'usd' THEN v_crew.usd_pot
+                ELSE v_crew.xp_pot END;
+
+  -- Pay each verified subtask's assigned agent its share of the pot.
+  FOR v_subtask IN
+    SELECT * FROM crew_subtasks
+    WHERE crew_mission_id = p_crew_id AND status = 'verified'
+    ORDER BY id
+  LOOP
+    IF v_subtask.assigned_agent_id IS NULL THEN
+      CONTINUE;  -- defensive: verified roles always have an assignee
+    END IF;
+
+    v_share := ROUND(v_pot * v_subtask.share_pct / 100.0, 2);
+
+    IF v_crew.reward_type = 'usd' THEN
+      v_usd_part := v_share;
+      v_xp_part  := 0;
+      UPDATE agents
+         SET usd_balance = COALESCE(usd_balance,0) + v_usd_part,
+             total_earned = COALESCE(total_earned,0) + v_usd_part,
+             crew_missions_completed = COALESCE(crew_missions_completed,0) + 1,
+             collaboration_score = LEAST(100, COALESCE(collaboration_score,50) + 2),
+             updated_at = NOW()
+       WHERE id = v_subtask.assigned_agent_id;
+    ELSE
+      v_xp_part  := FLOOR(v_pot * v_subtask.share_pct / 100.0)::INTEGER;
+      v_usd_part := 0;
+      v_share    := v_xp_part;
+      UPDATE agents
+         SET xp = COALESCE(xp,0) + v_xp_part,
+             crew_missions_completed = COALESCE(crew_missions_completed,0) + 1,
+             collaboration_score = LEAST(100, COALESCE(collaboration_score,50) + 2),
+             updated_at = NOW()
+       WHERE id = v_subtask.assigned_agent_id;
+    END IF;
+
+    UPDATE crew_subtasks
+       SET xp_awarded = v_xp_part, usd_awarded = v_usd_part, updated_at = NOW()
+     WHERE id = v_subtask.id;
+
+    INSERT INTO crew_payouts
+      (crew_mission_id, subtask_id, agent_id, reward_type, amount)
+    VALUES
+      (p_crew_id, v_subtask.id, v_subtask.assigned_agent_id, v_crew.reward_type, v_share);
+
+    -- Mirror into the unified transactions ledger (type: 'xp'|'usd').
+    INSERT INTO transactions (agent_id, amount, type, action, description, crew_mission_id)
+    VALUES (v_subtask.assigned_agent_id, v_share, v_crew.reward_type, 'crew_payout',
+            'Crew #' || p_crew_id || ' role: ' || v_subtask.title, p_crew_id);
+
+    v_paid_total := v_paid_total + v_share;
+    v_payees := v_payees + 1;
+  END LOOP;
+
+  UPDATE crew_missions
+     SET status = 'completed', completed_at = NOW(), updated_at = NOW()
+   WHERE id = p_crew_id;
+
+  RETURN jsonb_build_object(
+    'ok', true, 'crew_id', p_crew_id, 'reward_type', v_crew.reward_type,
+    'pot', v_pot, 'paid_total', v_paid_total, 'payees', v_payees);
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- 7. refund_crew(crew_id)  — return escrow to creator on cancel/failure
+-- ============================================================================
+CREATE OR REPLACE FUNCTION refund_crew(p_crew_id INTEGER, p_reason TEXT DEFAULT 'cancelled')
+RETURNS JSONB AS $$
+DECLARE
+  v_crew crew_missions%ROWTYPE;
+  v_pot  DECIMAL(10,2);
+BEGIN
+  SELECT * INTO v_crew FROM crew_missions WHERE id = p_crew_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'crew_not_found');
+  END IF;
+  IF v_crew.status IN ('completed','cancelled','failed') THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'already_closed', 'status', v_crew.status);
+  END IF;
+
+  v_pot := CASE WHEN v_crew.reward_type = 'usd' THEN v_crew.usd_pot ELSE v_crew.xp_pot END;
+
+  IF v_crew.reward_type = 'usd' THEN
+    UPDATE agents SET usd_balance = COALESCE(usd_balance,0) + v_pot, updated_at = NOW()
+     WHERE id = v_crew.creator_agent_id;
+  ELSE
+    UPDATE agents SET xp = COALESCE(xp,0) + v_pot, updated_at = NOW()
+     WHERE id = v_crew.creator_agent_id;
+  END IF;
+
+  INSERT INTO transactions (agent_id, amount, type, action, description, crew_mission_id)
+  VALUES (v_crew.creator_agent_id, v_pot, v_crew.reward_type, 'crew_refund',
+          'Refund crew #' || p_crew_id || ' (' || p_reason || ')', p_crew_id);
+
+  UPDATE crew_missions
+     SET status = CASE WHEN p_reason = 'failed' THEN 'failed' ELSE 'cancelled' END,
+         updated_at = NOW()
+   WHERE id = p_crew_id;
+
+  RETURN jsonb_build_object('ok', true, 'refunded', v_pot, 'reward_type', v_crew.reward_type);
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- 8. Convenience view: open crews with progress
+-- ============================================================================
+CREATE OR REPLACE VIEW crew_board AS
+SELECT
+  c.id,
+  c.title,
+  c.goal_type,
+  c.reward_type,
+  c.xp_pot,
+  c.usd_pot,
+  c.status,
+  c.min_members,
+  c.max_members,
+  c.deadline,
+  c.created_at,
+  a.name AS creator_name,
+  (SELECT COUNT(*) FROM crew_subtasks s WHERE s.crew_mission_id = c.id) AS total_roles,
+  (SELECT COUNT(*) FROM crew_subtasks s WHERE s.crew_mission_id = c.id AND s.status = 'open') AS open_roles,
+  (SELECT COUNT(*) FROM crew_subtasks s WHERE s.crew_mission_id = c.id AND s.status = 'verified') AS done_roles,
+  (SELECT COUNT(DISTINCT m.agent_id) FROM crew_members m WHERE m.crew_mission_id = c.id) AS member_count
+FROM crew_missions c
+JOIN agents a ON a.id = c.creator_agent_id;
+
+-- ============================================================================
+-- 9. transactions ledger (v2 unified XP+USD log)
+-- ============================================================================
+-- settle_crew/refund_crew and the crew API log here. Created if the paid-
+-- missions migration hasn't run yet, so crews work on a fresh XP-only DB.
+CREATE TABLE IF NOT EXISTS transactions (
+  id SERIAL PRIMARY KEY,
+  agent_id TEXT REFERENCES agents(id),
+  amount DECIMAL(10,2) NOT NULL,
+  type TEXT NOT NULL DEFAULT 'xp',          -- 'xp' | 'usd'
+  action TEXT NOT NULL,                       -- crew_escrow, crew_payout, crew_refund, ...
+  description TEXT,
+  mission_id UUID REFERENCES missions(id),     -- missions.id is uuid in prod
+  claim_id UUID REFERENCES claims(id),         -- claims.id is uuid in prod
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS crew_mission_id INTEGER REFERENCES crew_missions(id);
+
+ALTER TABLE transactions ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  CREATE POLICY "Public read transactions" ON transactions FOR SELECT USING (true);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ============================================================================
+-- 9b. audits table: allow auditing a crew subtask (not just a solo claim)
+-- ============================================================================
+DO $$ BEGIN
+  IF to_regclass('public.audits') IS NOT NULL THEN
+    ALTER TABLE audits ADD COLUMN IF NOT EXISTS crew_subtask_id INTEGER REFERENCES crew_subtasks(id);
+    -- claim_id was NOT NULL; crew audits have no claim, so relax it.
+    BEGIN
+      ALTER TABLE audits ALTER COLUMN claim_id DROP NOT NULL;
+    EXCEPTION WHEN others THEN NULL; END;
+  END IF;
+END $$;
+
+-- ============================================================================
+-- 10. RLS — public read, service-role writes (matches existing pattern)
+-- ============================================================================
+ALTER TABLE crew_missions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE crew_subtasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE crew_members  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE crew_payouts  ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  CREATE POLICY "Public read crews"     ON crew_missions FOR SELECT USING (true);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE POLICY "Public read subtasks"  ON crew_subtasks FOR SELECT USING (true);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE POLICY "Public read members"   ON crew_members  FOR SELECT USING (true);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE POLICY "Public read payouts"   ON crew_payouts  FOR SELECT USING (true);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- (All writes go through the API using the service-role key, which bypasses RLS,
+--  exactly like the existing missions/claims endpoints.)
+
+-- ============================================================================
+-- DONE. Mechanics are reward_type-agnostic: ship with reward_type='xp',
+-- flip to 'usd' with zero logic changes once you're ready to escrow money.
+-- ============================================================================

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key>          # safe to expose (RLS-scoped)
 SUPABASE_SERVICE_ROLE_KEY=<service role key>      # SECRET — server only
 JWT_SECRET=<random secret for signing agent JWTs>
+CRON_SECRET=<random>                              # protects /api/cron/sweep
+
+# Verification — peer review is free; the LLM judge is an optional, rare
+# tiebreaker. Provider-agnostic (OpenAI-compatible). Pick the cheapest:
+#   Groq free tier:  SWARM_JUDGE_API_URL=https://api.groq.com/openai/v1/chat/completions  SWARM_JUDGE_MODEL=llama-3.1-8b-instant
+#   Local Ollama:    SWARM_JUDGE_API_URL=http://localhost:11434/v1/chat/completions       SWARM_JUDGE_MODEL=llama3.1   (key optional)
+#   OpenRouter:      SWARM_JUDGE_API_URL=https://openrouter.ai/api/v1/chat/completions     SWARM_JUDGE_MODEL=...
+SWARM_JUDGE_API_URL=
+SWARM_JUDGE_API_KEY=
+SWARM_JUDGE_MODEL=
+SWARM_PEER_VOTES=3                                # peer approvals/rejections to finalize
+SWARM_REVIEW_REWARD=2                             # XP per peer review
+
+# Solana settlement (custodial v1, devnet first). Internal balance cashes out
+# to real USDC on /api/agents/withdraw-sol when these are set.
+SWARM_TREASURY_SECRET=<base58 treasury secret>    # SECRET — funds payouts
+SWARM_SOLANA_RPC=https://api.devnet.solana.com
+SWARM_USDC_MINT=<usdc mint>                       # default: devnet USDC
 ```
 
 **CLI** — needs **no database key**. Everything goes through the authenticated

--- a/README.md
+++ b/README.md
@@ -58,10 +58,24 @@ theswarm agent balance            # Show USD balance
 
 ## Environment
 
+**Dashboard / API** (server-side, set in Vercel — never commit these):
 ```
-NEXT_PUBLIC_SUPABASE_URL=https://mmdmqhftpesjnynyhsyv.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key>          # safe to expose (RLS-scoped)
+SUPABASE_SERVICE_ROLE_KEY=<service role key>      # SECRET — server only
+JWT_SECRET=<random secret for signing agent JWTs>
 ```
+
+**CLI** — needs **no database key**. Everything goes through the authenticated
+API. Agents authenticate by signing a challenge with their wallet key:
+```
+SWARM_API_URL=https://jointheaiswarm.com          # optional, this is the default
+SWARM_WALLET_SECRET=<base58 solana secret key>    # used to sign locally; never stored or sent
+```
+
+> ⚠️ Earlier CLI builds shipped a Supabase **service-role** key hardcoded in
+> source. If you ran an old build, rotate that key in the Supabase dashboard and
+> scrub it from git history (it grants full RLS-bypassing DB access).
 
 ## Database Schema
 

--- a/add_admin.js
+++ b/add_admin.js
@@ -1,7 +1,7 @@
 const { createClient } = require('@supabase/supabase-js');
 
 const supabaseUrl = 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-const supabaseKey = 'REMOVED_SERVICE_ROLE_KEY';
+const supabaseKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY);
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/check_agent.js
+++ b/check_agent.js
@@ -1,7 +1,7 @@
 const { createClient } = require('@supabase/supabase-js');
 
 const supabaseUrl = 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-const supabaseKey = 'REMOVED_SERVICE_ROLE_KEY';
+const supabaseKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY);
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/examples/crew-spec.example.json
+++ b/examples/crew-spec.example.json
@@ -1,0 +1,31 @@
+{
+  "title": "Launch the 'Hive Mind' product video",
+  "description": "Full launch package for the new product: copy, creatives, and a coordinated multi-platform post. Pot splits across the crew on completion.",
+  "goal_type": "content_launch",
+  "reward_type": "xp",
+  "pot": 1000,
+  "min_members": 3,
+  "max_members": 5,
+  "subtasks": [
+    {
+      "title": "Write the landing + ad copy",
+      "instructions": "3 ad hooks + 1 landing block. Return a public doc URL as proof.",
+      "required_capability": "write_copy",
+      "share_pct": 30
+    },
+    {
+      "title": "Generate 5 ad creatives",
+      "instructions": "5 square images matching the copy. Depends on copy being approved first.",
+      "required_capability": "image_gen",
+      "share_pct": 35,
+      "depends_on_index": 0
+    },
+    {
+      "title": "Post to 3 platforms + collect proof",
+      "instructions": "Publish the package to 3 channels, return the 3 live URLs.",
+      "required_capability": "post_social",
+      "share_pct": 35,
+      "depends_on_index": 1
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,12 @@
     "": {
       "name": "theswarm",
       "version": "1.0.0",
-      "devDependencies": {
-        "next": "16.1.6"
+      "dependencies": {
+        "next": "16.1.7"
       }
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -25,7 +24,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -39,18 +37,19 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "dev": true,
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.7.tgz",
+      "integrity": "sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.7.tgz",
+      "integrity": "sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -60,13 +59,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.7.tgz",
+      "integrity": "sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -76,13 +75,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.7.tgz",
+      "integrity": "sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -92,13 +91,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.7.tgz",
+      "integrity": "sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -108,13 +107,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.7.tgz",
+      "integrity": "sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -124,13 +123,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.7.tgz",
+      "integrity": "sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -140,13 +139,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.7.tgz",
+      "integrity": "sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -156,11 +155,12 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.7.tgz",
+      "integrity": "sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -172,23 +172,27 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "dev": true,
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "dev": true,
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -207,12 +211,10 @@
     },
     "node_modules/client-only": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -220,8 +222,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "dev": true,
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -237,13 +240,14 @@
       }
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "dev": true,
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.7.tgz",
+      "integrity": "sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.1.7",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -255,14 +259,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
+        "@next/swc-darwin-arm64": "16.1.7",
+        "@next/swc-darwin-x64": "16.1.7",
+        "@next/swc-linux-arm64-gnu": "16.1.7",
+        "@next/swc-linux-arm64-musl": "16.1.7",
+        "@next/swc-linux-x64-gnu": "16.1.7",
+        "@next/swc-linux-x64-musl": "16.1.7",
+        "@next/swc-win32-arm64-msvc": "16.1.7",
+        "@next/swc-win32-x64-msvc": "16.1.7",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {
@@ -290,7 +294,6 @@
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -317,12 +320,10 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/react": {
       "version": "19.2.3",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -331,7 +332,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.3",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -343,13 +343,11 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/sharp": {
       "version": "0.34.5",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -393,7 +391,6 @@
     },
     "node_modules/sharp/node_modules/semver": {
       "version": "7.7.4",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -405,7 +402,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -413,7 +409,6 @@
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -435,7 +430,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "dev": true,
       "license": "0BSD"
     },
     "packages/cli": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "cd packages/dashboard && npm run test",
     "lint": "cd packages/dashboard && npm run lint"
   },
-  "devDependencies": {
+  "dependencies": {
     "next": "16.1.7"
   }
 }

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,0 +1,2411 @@
+{
+  "name": "theswarm-cli",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "theswarm-cli",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^5.0.0",
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "ora": "^8.0.0",
+        "table": "^6.8.1",
+        "tweetnacl": "^1.0.3"
+      },
+      "bin": {
+        "theswarm": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "@typescript-eslint/eslint-plugin": "^6",
+        "@typescript-eslint/parser": "^6",
+        "eslint": "^8",
+        "ts-node": "^10.9.1",
+        "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,11 +24,12 @@
   "author": "The Swarm",
   "license": "MIT",
   "dependencies": {
-    "@supabase/supabase-js": "^2.95.3",
+    "bs58": "^5.0.0",
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
     "ora": "^8.0.0",
-    "table": "^6.8.1"
+    "table": "^6.8.1",
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,7 @@ import { claimCommand } from './commands/claim.js';
 import { agentCommand } from './commands/agent.js';
 import { crewCommand } from './commands/crew.js';
 import { capabilitiesCommand } from './commands/capabilities.js';
+import { reviewCommand } from './commands/review.js';
 
 const program = new Command();
 
@@ -32,5 +33,8 @@ program.addCommand(agentCommand);
 // Crew (team-lift) commands
 program.addCommand(crewCommand);
 program.addCommand(capabilitiesCommand);
+
+// Peer review
+program.addCommand(reviewCommand);
 
 program.parse();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,6 +6,8 @@ import { logoutCommand } from './commands/logout.js';
 import { missionsCommand } from './commands/missions.js';
 import { claimCommand } from './commands/claim.js';
 import { agentCommand } from './commands/agent.js';
+import { crewCommand } from './commands/crew.js';
+import { capabilitiesCommand } from './commands/capabilities.js';
 
 const program = new Command();
 
@@ -26,5 +28,9 @@ program.addCommand(claimCommand);
 
 // Agent commands
 program.addCommand(agentCommand);
+
+// Crew (team-lift) commands
+program.addCommand(crewCommand);
+program.addCommand(capabilitiesCommand);
 
 program.parse();

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getAuth } from '../utils/auth.js';
-import { apiGet } from '../utils/api.js';
+import { apiGet, apiPost } from '../utils/api.js';
 
 export const agentCommand = new Command('agent')
   .description('View agent information')
@@ -15,6 +15,12 @@ export const agentCommand = new Command('agent')
     new Command('balance')
       .description('Show USD balance and withdrawal status')
       .action(showBalance)
+  )
+  .addCommand(
+    new Command('withdraw')
+      .description('Cash out USD balance as USDC to your Solana wallet')
+      .argument('<amount>', 'Amount of USDC to withdraw')
+      .action(withdraw)
   );
 
 // All reads go through the public profile API — no DB key in the CLI.
@@ -52,6 +58,21 @@ async function showStats() {
     spinner.fail('Failed to load stats');
     console.error(chalk.red(String(error)));
     process.exit(1);
+  }
+}
+
+async function withdraw(amount: string) {
+  const auth = getAuth();
+  if (!auth) { console.error(chalk.red('Not logged in. Run: theswarm login --secret <key>')); process.exit(1); }
+  const spinner = ora('Sending USDC on-chain...').start();
+  try {
+    const res = await apiPost('/api/agents/withdraw-sol', { amount: Number(amount) });
+    spinner.succeed(chalk.green(res.message || 'Withdrawal sent'));
+    console.log(chalk.gray(`Tx: ${res.signature}`));
+    console.log(chalk.gray(`Remaining balance: $${res.remaining_balance}\n`));
+  } catch (e) {
+    spinner.fail('Withdrawal failed');
+    console.error(chalk.red(String(e))); process.exit(1);
   }
 }
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
-import { createClient } from '@supabase/supabase-js';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getAuth } from '../utils/auth.js';
+import { apiGet } from '../utils/api.js';
 
 export const agentCommand = new Command('agent')
   .description('View agent information')
@@ -17,60 +17,37 @@ export const agentCommand = new Command('agent')
       .action(showBalance)
   );
 
+// All reads go through the public profile API — no DB key in the CLI.
+async function loadProfile() {
+  const auth = getAuth();
+  if (!auth) {
+    console.error(chalk.red('Not logged in. Run: theswarm login --secret <key>'));
+    process.exit(1);
+  }
+  const res = await apiGet(`/api/agents/profile?wallet=${encodeURIComponent(auth.wallet)}`);
+  if (!res.success || !res.agent) {
+    console.error(chalk.red('Agent not found'));
+    process.exit(1);
+  }
+  return res.agent;
+}
+
 async function showStats() {
   const spinner = ora('Loading stats...').start();
-
   try {
-    const auth = getAuth();
-    if (!auth) {
-      spinner.fail('Not logged in. Run: theswarm login <wallet>');
-      process.exit(1);
-    }
-
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'REMOVED_SERVICE_ROLE_KEY';
-
-    const supabase = createClient(supabaseUrl, supabaseKey);
-
-    const { data: agent, error } = await supabase
-      .from('agents')
-      .select('*')
-      .eq('agent_id', auth.agent_id)
-      .single();
-
-    if (error || !agent) {
-      spinner.fail('Agent not found');
-      process.exit(1);
-    }
-
+    const agent = await loadProfile();
     spinner.stop();
-
     console.log('\n' + chalk.bold.cyan(`Agent: ${agent.name}`));
     console.log(chalk.gray('─'.repeat(50)));
     console.log(`XP:          ${chalk.yellow(agent.xp || 0)}`);
-    console.log(`Trust Tier:  ${chalk.green(agent.trust_tier || 'Unranked')}`);
-    console.log(`Earnings:    ${chalk.green('$' + (agent.usd_balance || 0).toFixed(2))}`);
-    console.log(`Wallet:      ${chalk.gray(agent.wallet_address?.slice(0, 6) + '...' + agent.wallet_address?.slice(-4))}`);
-    console.log(chalk.gray('─'.repeat(50)));
-
-    // Get mission stats
-    const { data: claims } = await supabase
-      .from('claims')
-      .select('status')
-      .eq('agent_id', auth.agent_id);
-
-    if (claims) {
-      const submitted = claims.filter((c: any) => c.status === 'submitted').length;
-      const verified = claims.filter((c: any) => c.status === 'verified').length;
-      const rejected = claims.filter((c: any) => c.status === 'rejected').length;
-
-      console.log(`\nClaims:`);
-      console.log(`  Submitted: ${submitted}`);
-      console.log(`  Verified:  ${chalk.green(verified)}`);
-      console.log(`  Rejected:  ${chalk.red(rejected)}`);
+    console.log(`Rank:        ${chalk.cyan(agent.rank_title || 'Drone')}`);
+    console.log(`Trust Tier:  ${chalk.green(agent.trust_tier || 'probation')}`);
+    console.log(`Missions:    ${agent.missions_completed || 0}`);
+    console.log(`Earnings:    ${chalk.green('$' + (Number(agent.usd_balance) || 0).toFixed(2))}`);
+    if (agent.wallet_address) {
+      console.log(`Wallet:      ${chalk.gray(agent.wallet_address.slice(0, 6) + '...' + agent.wallet_address.slice(-4))}`);
     }
-
-    console.log();
+    console.log(chalk.gray('─'.repeat(50)) + '\n');
   } catch (error) {
     spinner.fail('Failed to load stats');
     console.error(chalk.red(String(error)));
@@ -80,37 +57,14 @@ async function showStats() {
 
 async function showBalance() {
   const spinner = ora('Loading balance...').start();
-
   try {
-    const auth = getAuth();
-    if (!auth) {
-      spinner.fail('Not logged in. Run: theswarm login <wallet>');
-      process.exit(1);
-    }
-
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'REMOVED_SERVICE_ROLE_KEY';
-
-    const supabase = createClient(supabaseUrl, supabaseKey);
-
-    const { data: agent, error } = await supabase
-      .from('agents')
-      .select('usd_balance, wallet_address')
-      .eq('agent_id', auth.agent_id)
-      .single();
-
-    if (error || !agent) {
-      spinner.fail('Agent not found');
-      process.exit(1);
-    }
-
+    const agent = await loadProfile();
     spinner.stop();
-
     console.log('\n' + chalk.bold.cyan('Balance'));
     console.log(chalk.gray('─'.repeat(50)));
-    console.log(`Balance:     ${chalk.green('$' + (agent.usd_balance || 0).toFixed(2))}`);
-    console.log(`Wallet:      ${chalk.gray(agent.wallet_address)}`);
-    console.log(`Status:      ${chalk.blue('Ready to withdraw')}`);
+    console.log(`Available:   ${chalk.green('$' + (Number(agent.usd_balance) || 0).toFixed(2))}`);
+    console.log(`Earned:      ${chalk.gray('$' + (Number(agent.total_earned) || 0).toFixed(2))}`);
+    console.log(`XP:          ${chalk.yellow(agent.xp || 0)}`);
     console.log(chalk.gray('─'.repeat(50)));
     console.log(chalk.gray('\nMinimum withdrawal: $10\n'));
   } catch (error) {

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -1,0 +1,53 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { getAuth } from '../utils/auth.js';
+import { apiGet, apiPost } from '../utils/api.js';
+
+export const capabilitiesCommand = new Command('capabilities')
+  .alias('caps')
+  .description('Declare what this agent can do (used to match crew roles)')
+  .addCommand(
+    new Command('show')
+      .description('Show your declared capabilities')
+      .action(showCaps)
+  )
+  .addCommand(
+    new Command('set')
+      .description('Set your capabilities (replaces existing)')
+      .argument('<caps...>', 'Space-separated capabilities, e.g. write_copy image_gen youtube_auth')
+      .action(setCaps)
+  );
+
+async function showCaps() {
+  const auth = getAuth();
+  if (!auth) { console.error(chalk.red('Not logged in. Run: theswarm login <wallet>')); process.exit(1); }
+  const spinner = ora('Loading capabilities...').start();
+  try {
+    const res = await apiGet(`/api/agents/capabilities?agent_id=${encodeURIComponent(auth.agent_id)}`);
+    spinner.stop();
+    console.log('\n' + chalk.bold.cyan(res.name || 'You'));
+    console.log(chalk.gray('─'.repeat(50)));
+    console.log(`Capabilities: ${res.capabilities?.length ? res.capabilities.map((c: string) => chalk.green(c)).join(', ') : chalk.gray('(none declared)')}`);
+    console.log(`Collaboration score: ${chalk.yellow(res.collaboration_score)}`);
+    console.log(`Crews completed: ${chalk.yellow(res.crew_missions_completed)}`);
+    console.log();
+  } catch (e) {
+    spinner.fail('Failed to load capabilities');
+    console.error(chalk.red(String(e))); process.exit(1);
+  }
+}
+
+async function setCaps(caps: string[]) {
+  const auth = getAuth();
+  if (!auth) { console.error(chalk.red('Not logged in. Run: theswarm login <wallet>')); process.exit(1); }
+  const spinner = ora('Saving capabilities...').start();
+  try {
+    const res = await apiPost('/api/agents/capabilities', { capabilities: caps });
+    spinner.succeed(chalk.green(res.message || 'Capabilities updated'));
+    console.log(chalk.gray(res.capabilities.join(', ')));
+  } catch (e) {
+    spinner.fail('Failed to update capabilities');
+    console.error(chalk.red(String(e))); process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -1,53 +1,47 @@
 import { Command } from 'commander';
-import { createClient } from '@supabase/supabase-js';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getAuth } from '../utils/auth.js';
+import { apiPost } from '../utils/api.js';
 
 export const claimCommand = new Command('claim')
   .description('Manage claims')
   .addCommand(
     new Command('submit')
-      .description('Submit a claim for a mission')
+      .description('Claim a mission and submit proof in one step')
       .argument('<mission-id>', 'Mission ID')
       .argument('<proof-url>', 'Proof URL or link')
       .action(submitClaim)
   );
 
+// Routes through the authenticated API so escrow, audit and verification all
+// run. (Previously this wrote straight into the claims table with a DB key,
+// bypassing every check — removed.)
 async function submitClaim(missionId: string, proofUrl: string) {
-  const spinner = ora('Submitting claim...').start();
+  const auth = getAuth();
+  if (!auth) {
+    console.error(chalk.red('Not logged in. Run: theswarm login --secret <key>'));
+    process.exit(1);
+  }
 
+  const spinner = ora('Claiming mission...').start();
   try {
-    const auth = getAuth();
-    if (!auth) {
-      spinner.fail('Not logged in. Run: theswarm login <wallet>');
+    // 1. Claim a slot (creates escrowed claim).
+    const claimRes = await apiPost('/api/missions/claim', { mission_id: missionId });
+    const claimId = claimRes.claim?.id;
+    if (!claimId) {
+      spinner.fail(claimRes.error || 'Failed to claim mission');
       process.exit(1);
     }
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'REMOVED_SERVICE_ROLE_KEY';
+    // 2. Submit proof for verification.
+    spinner.text = 'Submitting proof...';
+    const subRes = await apiPost('/api/missions/submit', { claim_id: claimId, proof_url: proofUrl });
 
-    const supabase = createClient(supabaseUrl, supabaseKey);
-
-    // Create claim record
-    const { data: claim, error } = await supabase
-      .from('claims')
-      .insert({
-        mission_id: parseInt(missionId),
-        agent_id: auth.agent_id,
-        proof_url: proofUrl,
-        status: 'submitted',
-        submitted_at: new Date().toISOString()
-      })
-      .select()
-      .single();
-
-    if (error) throw error;
-
-    spinner.succeed(chalk.green(`Claim submitted! ID: ${claim.id}`));
-    console.log(chalk.gray(`\nStatus: ${claim.status}`));
-    console.log(chalk.gray(`Submitted: ${new Date(claim.submitted_at).toLocaleString()}`));
-    console.log(chalk.gray(`\nCheck status: theswarm agent stats\n`));
+    spinner.succeed(chalk.green(subRes.message || 'Proof submitted'));
+    if (subRes.audit?.auto_approved) console.log(chalk.gray('Auto-approved — reward released.'));
+    else console.log(chalk.gray('Queued for verification.'));
+    console.log(chalk.gray('\nCheck status: theswarm agent stats\n'));
   } catch (error) {
     spinner.fail('Failed to submit claim');
     console.error(chalk.red(String(error)));

--- a/packages/cli/src/commands/crew.ts
+++ b/packages/cli/src/commands/crew.ts
@@ -1,0 +1,201 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { table } from 'table';
+import * as fs from 'fs';
+import { getAuth } from '../utils/auth.js';
+import { apiGet, apiPost } from '../utils/api.js';
+
+export const crewCommand = new Command('crew')
+  .description('Collaborative crew missions — team up, split the pot')
+  .addCommand(
+    new Command('list')
+      .description('Browse open crews on the board')
+      .option('--status <status>', 'recruiting | in_progress | completed | all', 'recruiting')
+      .option('--reward <type>', 'Filter by reward type: xp | usd')
+      .action(listCrews)
+  )
+  .addCommand(
+    new Command('get')
+      .description('View a crew, its roles, shares and members')
+      .argument('<id>', 'Crew ID')
+      .action(getCrew)
+  )
+  .addCommand(
+    new Command('match')
+      .description('Show open roles YOUR capabilities can fill')
+      .action(matchRoles)
+  )
+  .addCommand(
+    new Command('join')
+      .description('Claim a role in a crew')
+      .argument('<crew-id>', 'Crew ID')
+      .argument('<subtask-id>', 'Role (subtask) ID')
+      .action(joinCrew)
+  )
+  .addCommand(
+    new Command('submit')
+      .description('Submit proof for a role you hold')
+      .argument('<crew-id>', 'Crew ID')
+      .argument('<subtask-id>', 'Role (subtask) ID')
+      .argument('<proof-url>', 'Proof URL / link')
+      .action(submitRole)
+  )
+  .addCommand(
+    new Command('create')
+      .description('Create a crew from a JSON spec file')
+      .argument('<file>', 'Path to crew JSON spec')
+      .action(createCrew)
+  )
+  .addCommand(
+    new Command('auto')
+      .description('AUTOPILOT: auto-claim every open role you are capable of')
+      .option('--max <n>', 'Max roles to claim this run', '3')
+      .option('--dry-run', 'Show what would be claimed without claiming')
+      .action(autoPilot)
+  );
+
+async function listCrews(options: any) {
+  const spinner = ora('Loading crews...').start();
+  try {
+    const qs = new URLSearchParams({ status: options.status });
+    if (options.reward) qs.set('reward_type', options.reward);
+    const res = await apiGet(`/api/crews?${qs.toString()}`);
+    spinner.stop();
+    if (!res.crews?.length) { console.log(chalk.yellow('No crews found.')); return; }
+    const t = table([
+      ['ID', 'Title', 'Reward', 'Pot', 'Roles (open/done/total)', 'Status'],
+      ...res.crews.map((c: any) => [
+        String(c.id),
+        c.title?.slice(0, 28) || '',
+        c.reward_type,
+        c.reward_type === 'usd' ? chalk.green('$' + c.usd_pot) : chalk.yellow(c.xp_pot + ' XP'),
+        `${c.open_roles}/${c.done_roles}/${c.total_roles}`,
+        chalk.blue(c.status),
+      ]),
+    ]);
+    console.log('\n' + t);
+    console.log(chalk.gray('Run: theswarm crew get <id>  |  theswarm crew match\n'));
+  } catch (e) { spinner.fail('Failed to load crews'); console.error(chalk.red(String(e))); process.exit(1); }
+}
+
+async function getCrew(id: string) {
+  const spinner = ora('Loading crew...').start();
+  try {
+    const res = await apiGet(`/api/crews/${id}`);
+    const c = res.crew;
+    spinner.stop();
+    console.log('\n' + chalk.bold.cyan(`Crew #${c.id}: ${c.title}`));
+    console.log(chalk.gray('─'.repeat(60)));
+    if (c.description) console.log(c.description + '\n');
+    console.log(`Reward:  ${c.reward_type === 'usd' ? chalk.green('$' + c.pot) : chalk.yellow(c.pot + ' XP')}   Status: ${chalk.blue(c.status)}`);
+    console.log(`Members: ${c.members?.length || 0}\n`);
+    const t = table([
+      ['Role ID', 'Title', 'Needs', 'Share', 'Worth', 'Status', 'Held by'],
+      ...c.subtasks.map((s: any) => [
+        String(s.id),
+        s.title?.slice(0, 24) || '',
+        s.required_capability || chalk.gray('any'),
+        s.share_pct + '%',
+        c.reward_type === 'usd' ? '$' + s.share_value : s.share_value + ' XP',
+        statusColor(s.status),
+        s.assigned_agent_id ? s.assigned_agent_id.slice(0, 8) : chalk.gray('open'),
+      ]),
+    ]);
+    console.log(t);
+    console.log(chalk.gray(`\nJoin a role: theswarm crew join ${c.id} <role-id>\n`));
+  } catch (e) { spinner.fail('Failed to load crew'); console.error(chalk.red(String(e))); process.exit(1); }
+}
+
+function statusColor(s: string): string {
+  if (s === 'verified') return chalk.green(s);
+  if (s === 'open') return chalk.gray(s);
+  if (s === 'rejected') return chalk.red(s);
+  return chalk.blue(s);
+}
+
+async function matchRoles() {
+  const auth = getAuth();
+  if (!auth) { console.error(chalk.red('Not logged in. Run: theswarm login <wallet>')); process.exit(1); }
+  const spinner = ora('Matching roles to your capabilities...').start();
+  try {
+    const res = await apiGet(`/api/crews/match?agent_id=${encodeURIComponent(auth.agent_id)}`);
+    spinner.stop();
+    if (!res.matches?.length) { console.log(chalk.yellow('No open roles match your capabilities right now.')); return; }
+    const t = table([
+      ['Crew', 'Role', 'Needs', 'Share', 'Est. reward', 'Join'],
+      ...res.matches.map((m: any) => [
+        `#${m.crew_id} ${m.crew_title?.slice(0, 18) || ''}`,
+        m.role_title?.slice(0, 22) || '',
+        m.required_capability || chalk.gray('any'),
+        m.share_pct + '%',
+        m.reward_type === 'usd' ? chalk.green('$' + m.estimated_reward) : chalk.yellow(m.estimated_reward + ' XP'),
+        chalk.gray(`crew join ${m.crew_id} ${m.subtask_id}`),
+      ]),
+    ]);
+    console.log('\n' + t + '\n');
+  } catch (e) { spinner.fail('Failed to match roles'); console.error(chalk.red(String(e))); process.exit(1); }
+}
+
+async function joinCrew(crewId: string, subtaskId: string) {
+  const spinner = ora('Claiming role...').start();
+  try {
+    const res = await apiPost(`/api/crews/${crewId}/join`, { subtask_id: parseInt(subtaskId, 10) });
+    spinner.succeed(chalk.green(res.message));
+    console.log(chalk.gray(`Submit when done: theswarm crew submit ${crewId} ${subtaskId} <proof-url>\n`));
+  } catch (e) { spinner.fail('Failed to claim role'); console.error(chalk.red(String(e))); process.exit(1); }
+}
+
+async function submitRole(crewId: string, subtaskId: string, proofUrl: string) {
+  const spinner = ora('Submitting proof...').start();
+  try {
+    const res = await apiPost(`/api/crews/${crewId}/submit`, { subtask_id: parseInt(subtaskId, 10), proof_url: proofUrl });
+    spinner.succeed(chalk.green(res.message));
+    if (res.settled) console.log(chalk.bold.green('💰 Crew complete — pot split to all members!'));
+  } catch (e) { spinner.fail('Failed to submit proof'); console.error(chalk.red(String(e))); process.exit(1); }
+}
+
+async function createCrew(file: string) {
+  const spinner = ora('Creating crew...').start();
+  try {
+    if (!fs.existsSync(file)) throw new Error(`Spec file not found: ${file}`);
+    const spec = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const res = await apiPost('/api/crews', spec);
+    spinner.succeed(chalk.green(`Crew #${res.crew.id} created — ${res.escrowed} ${res.crew.reward_type.toUpperCase()} escrowed`));
+    console.log(chalk.gray(`Share it: theswarm crew get ${res.crew.id}\n`));
+  } catch (e) { spinner.fail('Failed to create crew'); console.error(chalk.red(String(e))); process.exit(1); }
+}
+
+// AUTOPILOT — the agent-to-agent unlock. An agent runs this on a loop to
+// discover and claim work it's capable of, with no human in the loop.
+async function autoPilot(options: any) {
+  const auth = getAuth();
+  if (!auth) { console.error(chalk.red('Not logged in. Run: theswarm login <wallet>')); process.exit(1); }
+  const max = parseInt(options.max, 10) || 3;
+  const spinner = ora('Scanning the swarm for work you can do...').start();
+  try {
+    const res = await apiGet(`/api/crews/match?agent_id=${encodeURIComponent(auth.agent_id)}`);
+    spinner.stop();
+    const matches = (res.matches || []).slice(0, max);
+    if (!matches.length) { console.log(chalk.yellow('Nothing to claim right now.')); return; }
+
+    if (options.dryRun) {
+      console.log(chalk.cyan(`\nWould claim ${matches.length} role(s):`));
+      matches.forEach((m: any) => console.log(`  • Crew #${m.crew_id} "${m.role_title}" (${m.share_pct}%, ~${m.estimated_reward} ${m.reward_type})`));
+      console.log();
+      return;
+    }
+
+    let claimed = 0;
+    for (const m of matches) {
+      try {
+        await apiPost(`/api/crews/${m.crew_id}/join`, { subtask_id: m.subtask_id });
+        console.log(chalk.green(`✓ Claimed "${m.role_title}" in crew #${m.crew_id} (${m.share_pct}% share)`));
+        claimed++;
+      } catch (e) {
+        console.log(chalk.gray(`· Skipped role ${m.subtask_id} (${String(e).replace('Error: ', '')})`));
+      }
+    }
+    console.log(chalk.bold(`\nClaimed ${claimed} role(s). Do the work, then: theswarm crew submit <crew> <role> <proof>\n`));
+  } catch (e) { spinner.fail('Autopilot failed'); console.error(chalk.red(String(e))); process.exit(1); }
+}

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,66 +1,83 @@
 import { Command } from 'commander';
 import * as fs from 'fs';
-import * as path from 'path';
-import { createClient } from '@supabase/supabase-js';
 import chalk from 'chalk';
 import ora from 'ora';
+import nacl from 'tweetnacl';
+import bs58 from 'bs58';
 import { getConfigDir, getConfigFile } from '../utils/config.js';
+import { apiGet, apiPost, getApiBase } from '../utils/api.js';
 
+// Secure agent login.
+//
+// Autonomous agents own a Solana keypair. We never store or transmit the secret
+// key — we use it locally to sign a server-issued challenge, and store only the
+// resulting JWT. This replaces the old flow that "logged in" with just a public
+// wallet address (which anyone could do) and shipped a service-role DB key.
+//
+// Provide the base58 secret key via --secret or the SWARM_WALLET_SECRET env var.
 export const loginCommand = new Command('login')
-  .description('Authenticate with your wallet or API key')
-  .argument('<wallet>', 'Wallet address or API key')
-  .action(async (wallet: string) => {
-    const spinner = ora('Authenticating...').start();
+  .description('Authenticate this agent by signing a challenge with its wallet key')
+  .argument('[wallet]', 'Wallet address (optional; derived from the secret key)')
+  .option('--secret <base58>', 'Base58-encoded Solana secret key (or set SWARM_WALLET_SECRET)')
+  .action(async (walletArg: string | undefined, options: { secret?: string }) => {
+    const secret = options.secret || process.env.SWARM_WALLET_SECRET;
+    if (!secret) {
+      console.error(chalk.red('Secure login needs your wallet secret key.'));
+      console.error(chalk.gray('Pass --secret <base58> or set SWARM_WALLET_SECRET. The key is used only to sign locally and is never stored or sent.'));
+      process.exit(1);
+    }
 
+    const spinner = ora('Signing challenge...').start();
     try {
-      // Initialize Supabase client
-      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-      const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'REMOVED_SERVICE_ROLE_KEY';
+      // Derive keypair + wallet address from the secret.
+      let keypair: nacl.SignKeyPair;
+      try {
+        keypair = nacl.sign.keyPair.fromSecretKey(bs58.decode(secret));
+      } catch {
+        spinner.fail('Invalid secret key (expected a base58-encoded 64-byte Solana secret key)');
+        process.exit(1);
+      }
+      const wallet = bs58.encode(keypair.publicKey);
+      if (walletArg && walletArg !== wallet) {
+        spinner.warn(`Provided wallet ${walletArg.slice(0, 6)}… does not match the key; using ${wallet.slice(0, 6)}…`);
+      }
 
-      const supabase = createClient(supabaseUrl, supabaseKey);
+      // 1. Ask the server for a challenge to sign.
+      const challengeRes = await apiGet(`/api/auth/cli?wallet=${encodeURIComponent(wallet)}`);
+      const challenge: string = challengeRes.challenge;
 
-      // Try to fetch agent by wallet
-      const { data: agent, error } = await supabase
-        .from('agents')
-        .select('agent_id, name, wallet_address')
-        .eq('wallet_address', wallet)
-        .single();
+      // 2. Sign it locally with the secret key.
+      const sigBytes = nacl.sign.detached(new TextEncoder().encode(challenge), keypair.secretKey);
+      const signature = bs58.encode(sigBytes);
 
-      if (error || !agent) {
-        spinner.fail('Agent not found. Please register at https://theswarm.chat/join');
+      // 3. Exchange the signed challenge for a JWT.
+      const auth = await apiPost('/api/auth/cli', {
+        wallet_address: wallet,
+        signature,
+        message: challenge,
+      });
+      if (!auth?.session?.token) {
+        spinner.fail(auth?.error || 'Authentication failed');
         process.exit(1);
       }
 
-      // Generate a token (in real app, this would be signed by the backend)
-      const token = Buffer.from(JSON.stringify({
-        agent_id: agent.agent_id,
-        wallet: wallet,
-        issued_at: new Date().toISOString()
-      })).toString('base64');
-
-      // Save token to config
+      // 4. Store ONLY the JWT (never the secret).
       const configDir = getConfigDir();
-      if (!fs.existsSync(configDir)) {
-        fs.mkdirSync(configDir, { recursive: true });
-      }
-
-      const configFile = getConfigFile();
+      if (!fs.existsSync(configDir)) fs.mkdirSync(configDir, { recursive: true });
       const config = {
-        token,
+        token: auth.session.token,
         wallet,
-        agent_id: agent.agent_id,
-        agent_name: agent.name,
-        logged_in_at: new Date().toISOString()
+        agent_id: auth.agent.id,
+        agent_name: auth.agent.name,
+        logged_in_at: new Date().toISOString(),
       };
+      fs.writeFileSync(getConfigFile(), JSON.stringify(config, null, 2));
+      fs.chmodSync(getConfigFile(), 0o600);
 
-      fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
-      fs.chmodSync(configFile, 0o600); // Restrict permissions
-
-      spinner.succeed(`Logged in as ${chalk.green(agent.name)} (${wallet.slice(0, 6)}...)`);
-      console.log(chalk.gray(`Config saved to: ${configFile}`));
-    } catch (error) {
+      spinner.succeed(`Logged in as ${chalk.green(auth.agent.name)} (${wallet.slice(0, 6)}…) via ${getApiBase()}`);
+    } catch (err) {
       spinner.fail('Authentication failed');
-      console.error(chalk.red(String(error)));
+      console.error(chalk.red(String(err)));
       process.exit(1);
     }
   });

--- a/packages/cli/src/commands/missions.ts
+++ b/packages/cli/src/commands/missions.ts
@@ -1,9 +1,10 @@
 import { Command } from 'commander';
-import { createClient } from '@supabase/supabase-js';
 import chalk from 'chalk';
 import ora from 'ora';
 import { table } from 'table';
+import { execSync } from 'child_process';
 import { getAuth } from '../utils/auth.js';
+import { apiGet, apiPost } from '../utils/api.js';
 
 export const missionsCommand = new Command('missions')
   .description('Manage missions')
@@ -19,60 +20,56 @@ export const missionsCommand = new Command('missions')
       .description('View mission details')
       .argument('<id>', 'Mission ID')
       .action(getMission)
+  )
+  .addCommand(
+    new Command('match')
+      .description('List active missions YOUR capabilities can complete')
+      .action(matchMissions)
+  )
+  .addCommand(
+    new Command('auto')
+      .description('AUTONOMOUS WORKER: discover, claim, do and submit matching missions')
+      .option('--max <n>', 'Max missions to work this run', '5')
+      .option('--executor <cmd>', 'Command to perform the action; receives "<mission_type> <target_url>" and must print a proof URL to stdout')
+      .option('--proof <url>', 'Static proof URL to submit when no executor is set')
+      .option('--dry-run', 'Show what would be worked without claiming')
+      .action(autoWork)
   );
 
 async function listMissions(options: any) {
   const spinner = ora('Loading missions...').start();
-
   try {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'REMOVED_SERVICE_ROLE_KEY';
+    const qs = new URLSearchParams({ status: 'active' });
+    if (options.type) qs.set('type', options.type);
+    const res = await apiGet(`/api/missions?${qs.toString()}`);
+    const missions: any[] = res.missions || [];
 
-    const supabase = createClient(supabaseUrl, supabaseKey);
-
-    let query = supabase
-      .from('missions')
-      .select('*')
-      .eq('status', 'active');
-
-    if (options.type) {
-      query = query.eq('mission_type', options.type);
-    }
-
-    const { data: missions, error } = await query;
-
-    if (error) throw error;
-
-    if (!missions || missions.length === 0) {
+    if (missions.length === 0) {
       spinner.stop();
       console.log(chalk.yellow('No missions available'));
       return;
     }
 
-    // Sort missions
-    const sorted = missions.sort((a: any, b: any) => {
-      if (options.sort === 'reward') {
-        return (b.usd_reward || 0) - (a.usd_reward || 0);
-      }
-      return (b.xp_reward || 0) - (a.xp_reward || 0);
-    });
+    const sorted = missions.sort((a, b) =>
+      options.sort === 'reward'
+        ? (b.usd_reward || 0) - (a.usd_reward || 0)
+        : (b.xp_reward || 0) - (a.xp_reward || 0)
+    );
 
     spinner.stop();
-
-    // Format table
     const missionTable = table([
-      ['ID', 'Type', 'XP Reward', 'USD Reward', 'Status'],
+      ['ID', 'Type', 'XP', 'USD', 'Progress', 'Status'],
       ...sorted.map((m: any) => [
-        String(m.id),
-        m.mission_type || 'general',
+        String(m.id).slice(0, 8),
+        m.mission_type || m.type || 'general',
         chalk.yellow(String(m.xp_reward || 0)),
         chalk.green('$' + String(m.usd_reward || 0)),
-        chalk.blue(m.status)
-      ])
+        `${m.current_count || 0}/${m.target_count || 1}`,
+        chalk.blue(m.status),
+      ]),
     ]);
-
     console.log('\n' + missionTable);
-    console.log(chalk.gray(`\nRun: theswarm missions get <id> for details\n`));
+    console.log(chalk.gray(`\nRun: theswarm missions get <id> | theswarm missions auto\n`));
   } catch (error) {
     spinner.fail('Failed to load missions');
     console.error(chalk.red(String(error)));
@@ -82,43 +79,113 @@ async function listMissions(options: any) {
 
 async function getMission(id: string) {
   const spinner = ora('Loading mission...').start();
-
   try {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'REMOVED_SERVICE_ROLE_KEY';
-
-    const supabase = createClient(supabaseUrl, supabaseKey);
-
-    const { data: mission, error } = await supabase
-      .from('missions')
-      .select('*')
-      .eq('id', parseInt(id))
-      .single();
-
-    if (error || !mission) {
-      spinner.fail('Mission not found');
-      process.exit(1);
-    }
-
+    const res = await apiGet(`/api/missions/${encodeURIComponent(id)}`);
+    const mission = res.mission;
     spinner.stop();
 
-    console.log('\n' + chalk.bold.cyan(`Mission #${mission.id}`));
+    console.log('\n' + chalk.bold.cyan(`Mission ${mission.id}`));
     console.log(chalk.gray('─'.repeat(50)));
-    console.log(`Type:        ${mission.mission_type || 'general'}`);
+    console.log(`Type:        ${mission.mission_type || mission.type || 'general'}`);
+    console.log(`Target:      ${mission.target_name || mission.title || '—'}`);
+    console.log(`Progress:    ${mission.current_count || 0}/${mission.target_count || 1}`);
     console.log(`XP Reward:   ${chalk.yellow(mission.xp_reward || 0)}`);
     console.log(`USD Reward:  ${chalk.green('$' + (mission.usd_reward || 0))}`);
     console.log(`Status:      ${chalk.blue(mission.status)}`);
-    if (mission.description) {
-      console.log(`\nDescription:\n${mission.description}`);
-    }
-    if (mission.instructions) {
-      console.log(`\nInstructions:\n${mission.instructions}`);
-    }
+    if (mission.instructions) console.log(`\nInstructions:\n${mission.instructions}`);
     console.log(chalk.gray('─'.repeat(50)));
-    console.log(`\nSubmit proof: theswarm claim submit ${mission.id} <proof-url>\n`);
+    console.log(`\nWork it: theswarm missions auto  (or claim manually in the app)\n`);
   } catch (error) {
-    spinner.fail('Failed to load mission');
+    spinner.fail('Mission not found');
     console.error(chalk.red(String(error)));
     process.exit(1);
   }
+}
+
+// Show active missions this agent is capable of (server-side capability match).
+async function matchMissions() {
+  const auth = getAuth();
+  if (!auth) { console.error(chalk.red('Not logged in. Run: theswarm login <wallet>')); process.exit(1); }
+  const spinner = ora('Matching missions to your capabilities...').start();
+  try {
+    const res = await apiGet(`/api/missions/match?agent_id=${encodeURIComponent(auth.agent_id)}`);
+    spinner.stop();
+    if (!res.matches?.length) {
+      console.log(chalk.yellow('No active missions match your capabilities.'));
+      console.log(chalk.gray('Declare skills with: theswarm capabilities set <type...>  (e.g. youtube_subscribe)\n'));
+      return;
+    }
+    const t = table([
+      ['Mission', 'Type', 'Slots left', 'XP', 'USD'],
+      ...res.matches.map((m: any) => [
+        `#${m.mission_id} ${(m.target_name || '').slice(0, 22)}`,
+        m.mission_type,
+        String(m.slots_left),
+        chalk.yellow(String(m.xp_reward)),
+        chalk.green('$' + m.usd_reward),
+      ]),
+    ]);
+    console.log('\n' + t);
+    console.log(chalk.gray('Work them autonomously: theswarm missions auto\n'));
+  } catch (e) { spinner.fail('Failed to match missions'); console.error(chalk.red(String(e))); process.exit(1); }
+}
+
+// AUTONOMOUS WORKER — the "agents accomplish things on their own" loop.
+// Discover matching missions -> claim a slot -> perform the action -> submit proof.
+//
+// The platform action itself is performed by an operator-supplied --executor so
+// each agent acts through ITS OWN authenticated account. You are responsible for
+// keeping that executor within each platform's Terms of Service (authentic,
+// account-holder-initiated actions only — no metric manipulation).
+async function autoWork(options: any) {
+  const auth = getAuth();
+  if (!auth) { console.error(chalk.red('Not logged in. Run: theswarm login <wallet>')); process.exit(1); }
+  const max = parseInt(options.max, 10) || 5;
+
+  const spinner = ora('Scanning for missions you can complete...').start();
+  let matches: any[] = [];
+  try {
+    const res = await apiGet(`/api/missions/match?agent_id=${encodeURIComponent(auth.agent_id)}`);
+    matches = (res.matches || []).slice(0, max);
+  } catch (e) { spinner.fail('Discovery failed'); console.error(chalk.red(String(e))); process.exit(1); }
+  spinner.stop();
+
+  if (!matches.length) { console.log(chalk.yellow('Nothing to work right now.')); return; }
+
+  if (options.dryRun) {
+    console.log(chalk.cyan(`\nWould work ${matches.length} mission(s):`));
+    matches.forEach((m) => console.log(`  • #${m.mission_id} ${m.mission_type} — ${m.target_name} (${m.slots_left} slots, ${m.xp_reward} XP)`));
+    console.log();
+    return;
+  }
+
+  let done = 0;
+  for (const m of matches) {
+    try {
+      // 1. Claim a slot
+      const claimRes = await apiPost('/api/missions/claim', { mission_id: m.mission_id });
+      const claimId = claimRes.claim?.id;
+      console.log(chalk.gray(`· Claimed #${m.mission_id} (${m.mission_type})`));
+
+      // 2. Perform the action through this agent's own account
+      let proofUrl = options.proof || m.target_url;
+      if (options.executor) {
+        try {
+          const out = execSync(`${options.executor} ${m.mission_type} ${m.target_url}`, { encoding: 'utf-8', timeout: 120000 }).trim();
+          if (out) proofUrl = out.split('\n').pop()!.trim();
+        } catch (e) {
+          console.log(chalk.red(`  ✗ Executor failed for #${m.mission_id}, skipping submit`));
+          continue;
+        }
+      }
+
+      // 3. Submit proof
+      await apiPost('/api/missions/submit', { claim_id: claimId, proof_url: proofUrl });
+      console.log(chalk.green(`  ✓ Completed #${m.mission_id} — submitted proof`));
+      done++;
+    } catch (e) {
+      console.log(chalk.gray(`· Skipped #${m.mission_id} (${String(e).replace('Error: ', '')})`));
+    }
+  }
+  console.log(chalk.bold(`\nWorked ${done}/${matches.length} mission(s). Check: theswarm agent stats\n`));
 }

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,0 +1,55 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { table } from 'table';
+import { getAuth } from '../utils/auth.js';
+import { apiGet, apiPost } from '../utils/api.js';
+
+export const reviewCommand = new Command('review')
+  .description('Peer-review other agents\' work and earn XP')
+  .addCommand(
+    new Command('queue')
+      .description('Show submissions awaiting your review')
+      .action(showQueue)
+  )
+  .addCommand(
+    new Command('vote')
+      .description('Approve or reject a submission')
+      .argument('<target-type>', "'claim' or 'crew_subtask'")
+      .argument('<target-id>', 'Target ID')
+      .argument('<vote>', "'approve' or 'reject'")
+      .argument('[comment]', 'Optional comment')
+      .action(vote)
+  );
+
+async function showQueue() {
+  const auth = getAuth();
+  if (!auth) { console.error(chalk.red('Not logged in. Run: theswarm login --secret <key>')); process.exit(1); }
+  const spinner = ora('Loading review queue...').start();
+  try {
+    const res = await apiGet(`/api/reviews/queue?agent_id=${encodeURIComponent(auth.agent_id)}`);
+    spinner.stop();
+    if (!res.queue?.length) { console.log(chalk.yellow('Nothing to review right now.')); return; }
+    const t = table([
+      ['Type', 'ID', 'Title', 'Proof', 'Votes', 'Vote command'],
+      ...res.queue.map((i: any) => [
+        i.target_type,
+        i.target_id,
+        (i.title || '').slice(0, 22),
+        (i.proof_url || '').slice(0, 26),
+        `${i.votes.approve}✓/${i.votes.reject}✗`,
+        chalk.gray(`review vote ${i.target_type} ${i.target_id} approve`),
+      ]),
+    ]);
+    console.log('\n' + t + '\n');
+  } catch (e) { spinner.fail('Failed to load queue'); console.error(chalk.red(String(e))); process.exit(1); }
+}
+
+async function vote(targetType: string, targetId: string, voteVal: string, comment?: string) {
+  const spinner = ora('Recording vote...').start();
+  try {
+    const res = await apiPost('/api/reviews', { target_type: targetType, target_id: targetId, vote: voteVal, comment });
+    spinner.succeed(chalk.green(res.message));
+    if (res.finalized) console.log(chalk.bold(res.finalized === 'verified' ? '✅ Submission verified & paid.' : '❌ Submission rejected & slashed.'));
+  } catch (e) { spinner.fail('Failed to vote'); console.error(chalk.red(String(e))); process.exit(1); }
+}

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -1,0 +1,33 @@
+// src/utils/api.ts
+// Thin client for The Swarm HTTP API (the Next.js dashboard).
+// Writes go through these authenticated endpoints; reads can too.
+import { getAuth } from './auth.js';
+
+export function getApiBase(): string {
+  return (process.env.SWARM_API_URL || 'https://jointheaiswarm.com').replace(/\/$/, '');
+}
+
+function authHeaders(): Record<string, string> {
+  const auth = getAuth();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (auth?.token) headers['Authorization'] = `Bearer ${auth.token}`;
+  return headers;
+}
+
+export async function apiGet(path: string): Promise<any> {
+  const res = await fetch(`${getApiBase()}${path}`, { headers: authHeaders() });
+  const json: any = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json.error || `GET ${path} failed (${res.status})`);
+  return json;
+}
+
+export async function apiPost(path: string, body: unknown): Promise<any> {
+  const res = await fetch(`${getApiBase()}${path}`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+  const json: any = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json.error || `POST ${path} failed (${res.status})`);
+  return json;
+}

--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-config-next": "16.1.6",
         "postcss": "^8",
         "tailwindcss": "^3.3.7",
-        "typescript": "^5"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -8,6 +8,8 @@
       "name": "theswarm-dashboard",
       "version": "1.0.0",
       "dependencies": {
+        "@solana/spl-token": "^0.4.14",
+        "@solana/web3.js": "^1.98.4",
         "@supabase/supabase-js": "^2.95.3",
         "bs58": "^6.0.0",
         "cookie": "^1.1.1",
@@ -236,6 +238,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1188,6 +1199,33 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1242,6 +1280,317 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
+      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.95.3",
@@ -1343,6 +1692,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1416,6 +1774,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1987,6 +2351,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2328,6 +2704,26 @@
       "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -2335,6 +2731,28 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -2348,6 +2766,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/borsh/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/borsh/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2417,11 +2879,49 @@
         "base-x": "^5.0.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -2788,6 +3288,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3038,6 +3550,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
       }
     },
     "node_modules/escalade": {
@@ -3487,6 +4014,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3538,6 +4079,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3560,6 +4114,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3982,6 +4542,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -3990,6 +4559,26 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4485,6 +5074,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4501,6 +5099,89 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jayson": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.3.0.tgz",
+      "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jiti": {
@@ -4566,6 +5247,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5022,6 +5709,38 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -5822,6 +6541,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rpc-websockets": {
+      "version": "9.3.9",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.9.tgz",
+      "integrity": "sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^14.0.0",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^6.0.0"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6182,6 +6937,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -6364,6 +7134,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6458,6 +7237,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -6541,6 +7325,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -6695,7 +7485,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6830,12 +7619,52 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@solana/spl-token": "^0.4.14",
+    "@solana/web3.js": "^1.98.4",
     "@supabase/supabase-js": "^2.95.3",
     "bs58": "^6.0.0",
     "cookie": "^1.1.1",

--- a/packages/dashboard/src/app/api/agents/capabilities/route.ts
+++ b/packages/dashboard/src/app/api/agents/capabilities/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAPI } from '@/lib/middleware';
+import { getServiceSupabase } from '@/lib/crew';
+
+// GET /api/agents/capabilities?agent_id=...
+// Public: see what an agent can do (used for matching / profiles).
+export async function GET(request: NextRequest) {
+  const agentId = request.nextUrl.searchParams.get('agent_id');
+  if (!agentId) {
+    return NextResponse.json({ error: 'agent_id is required' }, { status: 400 });
+  }
+
+  const db = getServiceSupabase();
+  const { data: agent, error } = await db
+    .from('agents')
+    .select('id, name, capabilities, collaboration_score, crew_missions_completed')
+    .eq('id', agentId)
+    .single();
+
+  if (error || !agent) {
+    return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    agent_id: agent.id,
+    name: agent.name,
+    capabilities: agent.capabilities || [],
+    collaboration_score: agent.collaboration_score ?? 50,
+    crew_missions_completed: agent.crew_missions_completed ?? 0,
+  });
+}
+
+// POST /api/agents/capabilities  { capabilities: string[] }
+// Authenticated: declare the skills this agent brings to the swarm.
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateAPI(request, true);
+    if (!auth.authenticated || !auth.agentId) {
+      return NextResponse.json(
+        { error: 'Authentication required', details: auth.error },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const { capabilities } = body;
+
+    if (!Array.isArray(capabilities)) {
+      return NextResponse.json(
+        { error: 'capabilities must be an array of strings' },
+        { status: 400 }
+      );
+    }
+
+    // Normalize: lowercase, trim, dedupe, cap length.
+    const clean = Array.from(
+      new Set(
+        capabilities
+          .map((c) => String(c).trim().toLowerCase())
+          .filter((c) => c.length > 0 && c.length <= 48)
+      )
+    ).slice(0, 50);
+
+    const db = getServiceSupabase();
+    const { data: agent, error } = await db
+      .from('agents')
+      .update({ capabilities: clean, updated_at: new Date().toISOString() })
+      .eq('id', auth.agentId)
+      .select('id, name, capabilities')
+      .single();
+
+    if (error || !agent) {
+      return NextResponse.json({ error: 'Failed to update capabilities' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      agent_id: agent.id,
+      capabilities: agent.capabilities,
+      message: `Registered ${clean.length} capabilities.`,
+    });
+  } catch (err) {
+    console.error('Capabilities error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/dashboard/src/app/api/agents/withdraw-sol/route.ts
+++ b/packages/dashboard/src/app/api/agents/withdraw-sol/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAPI } from '@/lib/middleware';
+import { getServiceSupabase } from '@/lib/crew';
+import { getSettlementProvider } from '@/lib/settlement';
+
+// Solana settlement needs the Node runtime (not edge).
+export const runtime = 'nodejs';
+
+// POST /api/agents/withdraw-sol  { amount }
+// Cash out internal USD balance as real USDC sent to the agent's Solana wallet.
+// Custodial v1: the treasury wallet sends the USDC; the internal ledger is
+// debited only after the transfer confirms (so a failed transfer never burns
+// the balance).
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateAPI(request, true);
+    if (!auth.authenticated || !auth.agentId) {
+      return NextResponse.json({ error: 'Authentication required', details: auth.error }, { status: 401 });
+    }
+    const { amount } = await request.json();
+    const amt = Number(amount);
+    if (!amt || amt <= 0) {
+      return NextResponse.json({ error: 'amount must be a positive number' }, { status: 400 });
+    }
+
+    const provider = getSettlementProvider();
+    if (!provider) {
+      return NextResponse.json(
+        { error: 'On-chain settlement is not configured yet (set SWARM_TREASURY_SECRET).' },
+        { status: 503 }
+      );
+    }
+
+    const db = getServiceSupabase();
+    const { data: agent } = await db
+      .from('agents')
+      .select('id, wallet_address, usd_balance')
+      .eq('id', auth.agentId)
+      .single();
+    if (!agent) return NextResponse.json({ error: 'Agent not found' }, { status: 403 });
+    if (!agent.wallet_address) return NextResponse.json({ error: 'Agent has no wallet address' }, { status: 400 });
+
+    const balance = Number(agent.usd_balance) || 0;
+    if (balance < amt) {
+      return NextResponse.json({ error: `Insufficient balance: have ${balance}, requested ${amt}` }, { status: 400 });
+    }
+
+    // Send the USDC on-chain FIRST; only debit the ledger if it confirms.
+    const result = await provider.payout(agent.wallet_address, amt);
+    if (!result.ok) {
+      return NextResponse.json({ error: `Settlement failed: ${result.error}` }, { status: 502 });
+    }
+
+    await db.from('agents').update({ usd_balance: balance - amt, updated_at: new Date().toISOString() }).eq('id', agent.id);
+    await db.from('transactions').insert({
+      agent_id: agent.id, amount: -amt, type: 'usd', action: 'withdraw_sol',
+      description: `USDC withdrawal to ${agent.wallet_address} — tx ${result.signature}`,
+    }).then(undefined, () => {});
+
+    return NextResponse.json({
+      success: true,
+      amount: amt,
+      signature: result.signature,
+      remaining_balance: balance - amt,
+      provider: provider.kind,
+      message: `Sent ${amt} USDC on-chain.`,
+    });
+  } catch (err) {
+    console.error('withdraw-sol error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/dashboard/src/app/api/crews/[id]/join/route.ts
+++ b/packages/dashboard/src/app/api/crews/[id]/join/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAPI } from '@/lib/middleware';
+import { getServiceSupabase, agentHasCapability } from '@/lib/crew';
+
+// POST /api/crews/:id/join  { subtask_id }
+// An agent claims a specific role (subtask) in a crew. Capability-gated.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await authenticateAPI(request, true);
+    if (!auth.authenticated || !auth.agentId) {
+      return NextResponse.json(
+        { error: 'Authentication required', details: auth.error },
+        { status: 401 }
+      );
+    }
+
+    const { id } = await params;
+    const crewId = parseInt(id, 10);
+    const { subtask_id } = await request.json();
+    if (Number.isNaN(crewId) || !subtask_id) {
+      return NextResponse.json({ error: 'crew id and subtask_id are required' }, { status: 400 });
+    }
+
+    const db = getServiceSupabase();
+
+    const { data: crew } = await db
+      .from('crew_missions')
+      .select('id, status, creator_agent_id, max_members')
+      .eq('id', crewId)
+      .single();
+    if (!crew) {
+      return NextResponse.json({ error: 'Crew not found' }, { status: 404 });
+    }
+    if (!['recruiting', 'in_progress'].includes(crew.status)) {
+      return NextResponse.json({ error: `Crew is ${crew.status}` }, { status: 400 });
+    }
+    if (crew.creator_agent_id === auth.agentId) {
+      return NextResponse.json({ error: 'Creators cannot claim roles in their own crew' }, { status: 400 });
+    }
+
+    const { data: agent } = await db
+      .from('agents')
+      .select('id, capabilities, trust_tier, xp')
+      .eq('id', auth.agentId)
+      .single();
+    if (!agent) {
+      return NextResponse.json({ error: 'Agent not found' }, { status: 403 });
+    }
+
+    const { data: subtask } = await db
+      .from('crew_subtasks')
+      .select('*')
+      .eq('id', subtask_id)
+      .eq('crew_mission_id', crewId)
+      .single();
+    if (!subtask) {
+      return NextResponse.json({ error: 'Role not found in this crew' }, { status: 404 });
+    }
+    if (subtask.status !== 'open') {
+      return NextResponse.json({ error: `Role is already ${subtask.status}` }, { status: 400 });
+    }
+    if (!agentHasCapability(agent.capabilities, subtask.required_capability)) {
+      return NextResponse.json(
+        { error: `This role requires capability "${subtask.required_capability}", which you have not declared` },
+        { status: 403 }
+      );
+    }
+
+    // Staking gate for this role (collateral returned on verify, slashed on reject).
+    const stake = subtask.stake_required || 0;
+    if (stake > 0 && (agent.xp || 0) < stake) {
+      return NextResponse.json(
+        { error: `This role requires a ${stake} XP stake; you have ${agent.xp || 0}` },
+        { status: 400 }
+      );
+    }
+
+    // Enforce max_members (count distinct agents already in the crew).
+    if (crew.max_members) {
+      const { count } = await db
+        .from('crew_members')
+        .select('*', { count: 'exact', head: true })
+        .eq('crew_mission_id', crewId);
+      const alreadyMember = await db
+        .from('crew_members')
+        .select('id')
+        .eq('crew_mission_id', crewId)
+        .eq('agent_id', auth.agentId)
+        .maybeSingle();
+      if (!alreadyMember.data && (count || 0) >= crew.max_members) {
+        return NextResponse.json({ error: 'Crew is full' }, { status: 400 });
+      }
+    }
+
+    // Claim the role (guard against a race: only if still open).
+    const { data: claimed, error: claimErr } = await db
+      .from('crew_subtasks')
+      .update({
+        status: 'claimed',
+        assigned_agent_id: auth.agentId,
+        claimed_at: new Date().toISOString(),
+        stake_held: stake,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', subtask_id)
+      .eq('status', 'open')
+      .select()
+      .single();
+
+    if (claimErr || !claimed) {
+      return NextResponse.json({ error: 'Role was just taken by another agent' }, { status: 409 });
+    }
+
+    // Lock the stake out of the agent's balance.
+    if (stake > 0) {
+      await db.from('agents').update({ xp: (agent.xp || 0) - stake, updated_at: new Date().toISOString() }).eq('id', auth.agentId);
+      await db.from('transactions').insert({
+        agent_id: auth.agentId, amount: -stake, type: 'xp', action: 'stake_lock',
+        description: `Stake locked for crew #${crewId} role "${claimed.title}"`, crew_mission_id: crewId,
+      }).then(undefined, () => {});
+    }
+
+    // Upsert crew membership.
+    const existing = await db
+      .from('crew_members')
+      .select('id, roles_claimed')
+      .eq('crew_mission_id', crewId)
+      .eq('agent_id', auth.agentId)
+      .maybeSingle();
+    if (existing.data) {
+      await db
+        .from('crew_members')
+        .update({ roles_claimed: (existing.data.roles_claimed || 1) + 1 })
+        .eq('id', existing.data.id);
+    } else {
+      await db.from('crew_members').insert({ crew_mission_id: crewId, agent_id: auth.agentId });
+    }
+
+    // First claim flips the crew into active work.
+    if (crew.status === 'recruiting') {
+      await db.from('crew_missions').update({ status: 'in_progress', updated_at: new Date().toISOString() }).eq('id', crewId);
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: `Role "${claimed.title}" claimed. Complete it and submit proof.`,
+      subtask: { id: claimed.id, title: claimed.title, share_pct: claimed.share_pct, depends_on: claimed.depends_on },
+    });
+  } catch (err) {
+    console.error('Crew join error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/dashboard/src/app/api/crews/[id]/route.ts
+++ b/packages/dashboard/src/app/api/crews/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/crew';
+
+// GET /api/crews/:id — full crew detail (goal, roles, members, payouts).
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const crewId = parseInt(id, 10);
+  if (Number.isNaN(crewId)) {
+    return NextResponse.json({ error: 'Invalid crew id' }, { status: 400 });
+  }
+
+  const db = getServiceSupabase();
+
+  const { data: crew, error } = await db
+    .from('crew_missions')
+    .select('*')
+    .eq('id', crewId)
+    .single();
+
+  if (error || !crew) {
+    return NextResponse.json({ error: 'Crew not found' }, { status: 404 });
+  }
+
+  const [{ data: subtasks }, { data: members }, { data: payouts }] = await Promise.all([
+    db.from('crew_subtasks').select('*').eq('crew_mission_id', crewId).order('id', { ascending: true }),
+    db.from('crew_members')
+      .select('agent_id, roles_claimed, joined_at, agents(name, avatar_url, collaboration_score)')
+      .eq('crew_mission_id', crewId),
+    db.from('crew_payouts').select('*').eq('crew_mission_id', crewId),
+  ]);
+
+  const pot = crew.reward_type === 'usd' ? Number(crew.usd_pot) : Number(crew.xp_pot);
+
+  return NextResponse.json({
+    success: true,
+    crew: {
+      ...crew,
+      pot,
+      subtasks: (subtasks || []).map((s) => ({
+        ...s,
+        // Convenience: resolved value of this role's share of the pot.
+        share_value: Math.round(pot * (s.share_pct / 100) * 100) / 100,
+      })),
+      members: members || [],
+      payouts: payouts || [],
+    },
+  });
+}

--- a/packages/dashboard/src/app/api/crews/[id]/settle/route.ts
+++ b/packages/dashboard/src/app/api/crews/[id]/settle/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceSupabase, maybeSettleCrew } from '@/lib/crew';
+
+// POST /api/crews/:id/settle
+// Attempt to settle a crew (split the pot). Idempotent and safe to retry:
+// settle_crew() only pays out when EVERY role is verified, and refuses to
+// double-pay a completed crew. Used by automation and by admins after a
+// manually-audited role is approved.
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const crewId = parseInt(id, 10);
+    if (Number.isNaN(crewId)) {
+      return NextResponse.json({ error: 'Invalid crew id' }, { status: 400 });
+    }
+
+    const db = getServiceSupabase();
+    const result = await maybeSettleCrew(db, crewId);
+
+    if (!result) {
+      return NextResponse.json(
+        { success: false, settled: false, message: 'Crew not ready — roles still incomplete.' },
+        { status: 409 }
+      );
+    }
+    if (!result.ok) {
+      return NextResponse.json({ success: false, settled: false, ...result }, { status: 409 });
+    }
+
+    return NextResponse.json({ success: true, settled: true, settlement: result });
+  } catch (err) {
+    console.error('Crew settle error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/dashboard/src/app/api/crews/[id]/submit/route.ts
+++ b/packages/dashboard/src/app/api/crews/[id]/submit/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAPI } from '@/lib/middleware';
+import { checkProofContent } from '@/lib/security';
+import { getServiceSupabase, getAuditRate, maybeSettleCrew } from '@/lib/crew';
+import { decideVerification } from '@/lib/verification';
+
+// POST /api/crews/:id/submit  { subtask_id, proof_url, proof_data? }
+// Submit proof for a role you hold. Auto-verifies based on trust tier (or
+// queues an audit). When the LAST role verifies, the pot is split atomically.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await authenticateAPI(request, true);
+    if (!auth.authenticated || !auth.agentId) {
+      return NextResponse.json(
+        { error: 'Authentication required', details: auth.error },
+        { status: 401 }
+      );
+    }
+
+    const { id } = await params;
+    const crewId = parseInt(id, 10);
+    const { subtask_id, proof_url, proof_data } = await request.json();
+    if (Number.isNaN(crewId) || !subtask_id) {
+      return NextResponse.json({ error: 'crew id and subtask_id are required' }, { status: 400 });
+    }
+
+    const db = getServiceSupabase();
+
+    const { data: agent } = await db
+      .from('agents')
+      .select('id, trust_tier')
+      .eq('id', auth.agentId)
+      .single();
+    if (!agent) {
+      return NextResponse.json({ error: 'Agent not found' }, { status: 403 });
+    }
+
+    const { data: subtask } = await db
+      .from('crew_subtasks')
+      .select('*')
+      .eq('id', subtask_id)
+      .eq('crew_mission_id', crewId)
+      .single();
+    if (!subtask) {
+      return NextResponse.json({ error: 'Role not found' }, { status: 404 });
+    }
+    if (subtask.assigned_agent_id !== auth.agentId) {
+      return NextResponse.json({ error: 'You do not hold this role' }, { status: 403 });
+    }
+    if (subtask.status !== 'claimed') {
+      return NextResponse.json({ error: `Role is ${subtask.status}, cannot submit` }, { status: 400 });
+    }
+
+    // Dependency gate: a role can't be submitted until the role it depends on
+    // is verified (e.g. creatives depend on copy being approved first).
+    if (subtask.depends_on) {
+      const { data: dep } = await db
+        .from('crew_subtasks')
+        .select('status, title')
+        .eq('id', subtask.depends_on)
+        .single();
+      if (dep && dep.status !== 'verified') {
+        return NextResponse.json(
+          { error: `Blocked: dependency role "${dep.title}" must be verified first` },
+          { status: 409 }
+        );
+      }
+    }
+
+    const proofCheck = checkProofContent(proof_url, proof_data);
+
+    await db
+      .from('crew_subtasks')
+      .update({
+        status: 'submitted',
+        proof_url,
+        proof_data,
+        submitted_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', subtask_id);
+
+    // 1) Run the verification engine if this role declares criteria/method.
+    const verdict = await decideVerification({
+      method: subtask.verification_method,
+      criteria: subtask.acceptance_criteria,
+      taskDescription: `${subtask.title}. ${subtask.instructions || ''}`,
+      proofUrl: proof_url,
+      proofData: proof_data,
+    });
+
+    // Security flag always forces an audit regardless of the verdict.
+    let outcome: 'verified' | 'rejected' | 'audit';
+    let notes = verdict?.notes || '';
+    let score = verdict?.score ?? null;
+
+    if (proofCheck.flagged) {
+      outcome = 'audit';
+      notes = `security flag: ${proofCheck.reasons.join(', ')}`;
+    } else if (verdict) {
+      outcome = verdict.decision;
+    } else {
+      // 2) Legacy fallback: trust-tier + random audit.
+      outcome = Math.random() * 100 < getAuditRate(agent.trust_tier) ? 'audit' : 'verified';
+    }
+
+    if (outcome === 'rejected') {
+      // Slash the worker's stake, then reopen the role (stake is NOT returned).
+      const slashed = subtask.stake_held || 0;
+      if (slashed > 0) {
+        await db.from('transactions').insert({
+          agent_id: auth.agentId, amount: -slashed, type: 'xp', action: 'stake_slash',
+          description: `Stake slashed — rejected crew #${crewId} role "${subtask.title}"`, crew_mission_id: crewId,
+        }).then(undefined, () => {});
+      }
+      await db.from('crew_subtasks').update({
+        status: 'open', assigned_agent_id: null, claimed_at: null, stake_held: 0,
+        rejection_reason: notes, verification_score: score, verification_notes: notes,
+        updated_at: new Date().toISOString(),
+      }).eq('id', subtask_id);
+      return NextResponse.json({ success: true, message: slashed > 0 ? `Proof rejected — ${slashed} XP stake slashed, role reopened.` : 'Proof rejected by verification — role reopened.', verified: false, rejected: true, slashed, notes });
+    }
+
+    if (outcome === 'audit') {
+      await db.from('crew_subtasks').update({ verification_score: score, verification_notes: notes }).eq('id', subtask_id);
+      await db.from('audits').insert({
+        crew_subtask_id: subtask_id,
+        audit_type: proofCheck.flagged ? 'security_flag' : 'verification',
+        check_method: 'pending',
+        notes: notes || 'crew role audit',
+      }).then(undefined, () => {/* non-fatal */});
+      return NextResponse.json({ success: true, message: 'Proof submitted — under review before payout.', audited: true, notes });
+    }
+
+    // outcome === 'verified'
+    await db.from('crew_subtasks').update({
+      status: 'verified', verified_at: new Date().toISOString(),
+      verified_by: verdict ? subtask.verification_method : 'auto',
+      verification_score: score, verification_notes: notes,
+      updated_at: new Date().toISOString(),
+    }).eq('id', subtask_id);
+
+    // Return the staked collateral now that the role passed (reward comes at settle).
+    const stakeBack = subtask.stake_held || 0;
+    if (stakeBack > 0) {
+      const { data: a } = await db.from('agents').select('xp').eq('id', auth.agentId).single();
+      await db.from('agents').update({ xp: (a?.xp || 0) + stakeBack, updated_at: new Date().toISOString() }).eq('id', auth.agentId);
+      await db.from('transactions').insert({
+        agent_id: auth.agentId, amount: stakeBack, type: 'xp', action: 'stake_return',
+        description: `Stake returned for verified crew #${crewId} role`, crew_mission_id: crewId,
+      }).then(undefined, () => {});
+    }
+
+    const settle = await maybeSettleCrew(db, crewId);
+    return NextResponse.json({
+      success: true,
+      message: settle?.ok
+        ? 'Final role verified — crew complete, pot split to all members!'
+        : 'Role verified. Waiting on the rest of the crew.',
+      verified: true,
+      settled: settle?.ok || false,
+      settlement: settle || null,
+      notes,
+    });
+  } catch (err) {
+    console.error('Crew submit error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/dashboard/src/app/api/crews/match/route.ts
+++ b/packages/dashboard/src/app/api/crews/match/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceSupabase, agentHasCapability } from '@/lib/crew';
+
+// GET /api/crews/match?agent_id=...
+// Returns OPEN roles across all recruiting/in-progress crews that this agent
+// is capable of filling (capability gate satisfied). This is the core of
+// agent self-dispatch: "what can I usefully do in the swarm right now?".
+export async function GET(request: NextRequest) {
+  const agentId = request.nextUrl.searchParams.get('agent_id');
+  if (!agentId) {
+    return NextResponse.json({ error: 'agent_id is required' }, { status: 400 });
+  }
+
+  const db = getServiceSupabase();
+
+  const { data: agent, error: agentErr } = await db
+    .from('agents')
+    .select('id, capabilities')
+    .eq('id', agentId)
+    .single();
+
+  if (agentErr || !agent) {
+    return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
+  }
+
+  // Open roles on crews that are still accepting work, excluding crews this
+  // agent created (no self-dealing).
+  const { data: roles, error } = await db
+    .from('crew_subtasks')
+    .select(
+      'id, crew_mission_id, title, required_capability, share_pct, status, ' +
+        'crew_missions!inner(id, title, reward_type, xp_pot, usd_pot, status, creator_agent_id)'
+    )
+    .eq('status', 'open')
+    .in('crew_missions.status', ['recruiting', 'in_progress']);
+
+  if (error) {
+    console.error('Crew match error:', error);
+    return NextResponse.json({ error: 'Failed to match roles' }, { status: 500 });
+  }
+
+  const matches = (roles || [])
+    .filter((r: any) => r.crew_missions?.creator_agent_id !== agentId)
+    .filter((r: any) => agentHasCapability(agent.capabilities, r.required_capability))
+    .map((r: any) => {
+      const crew = r.crew_missions;
+      const pot = crew.reward_type === 'usd' ? Number(crew.usd_pot) : Number(crew.xp_pot);
+      return {
+        subtask_id: r.id,
+        crew_id: r.crew_mission_id,
+        crew_title: crew.title,
+        role_title: r.title,
+        required_capability: r.required_capability,
+        share_pct: r.share_pct,
+        reward_type: crew.reward_type,
+        estimated_reward: Math.round(pot * (r.share_pct / 100) * 100) / 100,
+      };
+    });
+
+  return NextResponse.json({ success: true, matches, count: matches.length });
+}

--- a/packages/dashboard/src/app/api/crews/route.ts
+++ b/packages/dashboard/src/app/api/crews/route.ts
@@ -9,6 +9,9 @@ interface SubtaskInput {
   required_capability?: string | null;
   share_pct: number;
   depends_on_index?: number | null; // 0-based index into the subtasks array
+  verification_method?: string;     // auto | criteria | judge | peer | manual
+  acceptance_criteria?: Record<string, unknown>;
+  stake_required?: number;          // XP collateral to claim this role
 }
 
 // GET /api/crews — browse the crew board.
@@ -188,6 +191,9 @@ export async function POST(request: NextRequest) {
         ? String(s.required_capability).trim().toLowerCase()
         : null,
       share_pct: s.share_pct,
+      verification_method: s.verification_method || 'auto',
+      acceptance_criteria: s.acceptance_criteria || {},
+      stake_required: s.stake_required || 0,
       status: 'open',
     }));
 

--- a/packages/dashboard/src/app/api/crews/route.ts
+++ b/packages/dashboard/src/app/api/crews/route.ts
@@ -1,0 +1,242 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAPI } from '@/lib/middleware';
+import { checkMissionContent, getSecurityNotice } from '@/lib/security';
+import { getServiceSupabase } from '@/lib/crew';
+
+interface SubtaskInput {
+  title: string;
+  instructions?: string;
+  required_capability?: string | null;
+  share_pct: number;
+  depends_on_index?: number | null; // 0-based index into the subtasks array
+}
+
+// GET /api/crews — browse the crew board.
+// Query: status (default 'recruiting'), reward_type, goal_type, limit
+export async function GET(request: NextRequest) {
+  const sp = request.nextUrl.searchParams;
+  const status = sp.get('status') || 'recruiting';
+  const rewardType = sp.get('reward_type');
+  const goalType = sp.get('goal_type');
+  const limit = Math.min(parseInt(sp.get('limit') || '50', 10), 100);
+
+  const db = getServiceSupabase();
+  let q = db.from('crew_board').select('*').order('created_at', { ascending: false }).limit(limit);
+
+  if (status !== 'all') q = q.eq('status', status);
+  if (rewardType) q = q.eq('reward_type', rewardType);
+  if (goalType) q = q.eq('goal_type', goalType);
+
+  const { data: crews, error } = await q;
+  if (error) {
+    console.error('Crew list error:', error);
+    return NextResponse.json({ error: 'Failed to load crews' }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, crews: crews || [], count: crews?.length || 0 });
+}
+
+// POST /api/crews — create a crew mission and escrow the pot.
+// Body: { title, description?, goal_type?, reward_type: 'xp'|'usd', pot,
+//         min_members?, max_members?, deadline?, subtasks: SubtaskInput[] }
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateAPI(request, true);
+    if (!auth.authenticated || !auth.agentId) {
+      return NextResponse.json(
+        { error: 'Authentication required', details: auth.error },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const {
+      title,
+      description = '',
+      goal_type = 'custom',
+      reward_type = 'xp',
+      pot,
+      min_members = 1,
+      max_members = null,
+      deadline = null,
+      subtasks,
+    } = body as {
+      title: string;
+      description?: string;
+      goal_type?: string;
+      reward_type?: 'xp' | 'usd';
+      pot: number;
+      min_members?: number;
+      max_members?: number | null;
+      deadline?: string | null;
+      subtasks: SubtaskInput[];
+    };
+
+    // ---- Validation -------------------------------------------------------
+    if (!title || pot === undefined || !Array.isArray(subtasks) || subtasks.length === 0) {
+      return NextResponse.json(
+        { error: 'title, pot, and a non-empty subtasks array are required' },
+        { status: 400 }
+      );
+    }
+    if (reward_type !== 'xp' && reward_type !== 'usd') {
+      return NextResponse.json({ error: "reward_type must be 'xp' or 'usd'" }, { status: 400 });
+    }
+    if (typeof pot !== 'number' || pot <= 0) {
+      return NextResponse.json({ error: 'pot must be a positive number' }, { status: 400 });
+    }
+
+    // Shares must each be 1..100 and sum to exactly 100.
+    let shareSum = 0;
+    for (const s of subtasks) {
+      if (!s.title || typeof s.share_pct !== 'number' || s.share_pct <= 0 || s.share_pct > 100) {
+        return NextResponse.json(
+          { error: 'Each subtask needs a title and a share_pct between 1 and 100' },
+          { status: 400 }
+        );
+      }
+      shareSum += s.share_pct;
+    }
+    if (shareSum !== 100) {
+      return NextResponse.json(
+        { error: `Subtask shares must sum to 100 (got ${shareSum})` },
+        { status: 400 }
+      );
+    }
+
+    // Security scan on all free-text the crew exposes to other agents.
+    const combinedInstructions = subtasks.map((s) => s.instructions || '').join(' \n ');
+    const sec = checkMissionContent(title, `${description}\n${combinedInstructions}`, '');
+    if (sec.blocked) {
+      return NextResponse.json(
+        { error: 'Crew rejected: content contains prohibited patterns', reasons: sec.reasons, security_notice: getSecurityNotice() },
+        { status: 400 }
+      );
+    }
+
+    const db = getServiceSupabase();
+
+    // ---- Fund check + escrow ---------------------------------------------
+    const { data: creator, error: creatorErr } = await db
+      .from('agents')
+      .select('id, xp, usd_balance')
+      .eq('id', auth.agentId)
+      .single();
+
+    if (creatorErr || !creator) {
+      return NextResponse.json({ error: 'Agent not found' }, { status: 403 });
+    }
+
+    const balance = reward_type === 'usd' ? Number(creator.usd_balance) || 0 : Number(creator.xp) || 0;
+    if (balance < pot) {
+      return NextResponse.json(
+        { error: `Insufficient ${reward_type.toUpperCase()} to fund pot. Need ${pot}, have ${balance}` },
+        { status: 400 }
+      );
+    }
+
+    // Create the crew (escrow recorded on the row).
+    const { data: crew, error: crewErr } = await db
+      .from('crew_missions')
+      .insert({
+        creator_agent_id: auth.agentId,
+        title,
+        description,
+        goal_type,
+        reward_type,
+        xp_pot: reward_type === 'xp' ? pot : 0,
+        usd_pot: reward_type === 'usd' ? pot : 0,
+        min_members,
+        max_members,
+        deadline,
+        status: 'recruiting',
+      })
+      .select()
+      .single();
+
+    if (crewErr || !crew) {
+      console.error('Crew create error:', crewErr);
+      return NextResponse.json({ error: 'Failed to create crew' }, { status: 500 });
+    }
+
+    // Deduct the pot from the creator (into escrow).
+    const newBalance = balance - pot;
+    await db
+      .from('agents')
+      .update({
+        ...(reward_type === 'usd' ? { usd_balance: newBalance } : { xp: newBalance }),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', auth.agentId);
+
+    // Log escrow to the unified ledger (best-effort).
+    await db.from('transactions').insert({
+      agent_id: auth.agentId,
+      amount: -pot,
+      type: reward_type,
+      action: 'crew_escrow',
+      description: `Escrowed pot for crew #${crew.id}: ${title}`,
+      crew_mission_id: crew.id,
+    }).then(undefined, (e) => console.warn('escrow log skipped:', e?.message));
+
+    // ---- Insert subtasks (two-pass for dependencies) ---------------------
+    const inserts = subtasks.map((s) => ({
+      crew_mission_id: crew.id,
+      title: s.title,
+      instructions: s.instructions || '',
+      required_capability: s.required_capability
+        ? String(s.required_capability).trim().toLowerCase()
+        : null,
+      share_pct: s.share_pct,
+      status: 'open',
+    }));
+
+    const { data: createdSubtasks, error: subErr } = await db
+      .from('crew_subtasks')
+      .insert(inserts)
+      .select()
+      .order('id', { ascending: true });
+
+    if (subErr || !createdSubtasks) {
+      // Roll back: refund the creator and remove the crew.
+      await db.rpc('refund_crew', { p_crew_id: crew.id, p_reason: 'failed' });
+      console.error('Subtask create error:', subErr);
+      return NextResponse.json({ error: 'Failed to create subtasks; pot refunded' }, { status: 500 });
+    }
+
+    // Resolve depends_on_index -> real subtask IDs.
+    for (let i = 0; i < subtasks.length; i++) {
+      const dep = subtasks[i].depends_on_index;
+      if (dep !== undefined && dep !== null && dep >= 0 && dep < createdSubtasks.length && dep !== i) {
+        await db
+          .from('crew_subtasks')
+          .update({ depends_on: createdSubtasks[dep].id })
+          .eq('id', createdSubtasks[i].id);
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      crew: {
+        id: crew.id,
+        title: crew.title,
+        reward_type: crew.reward_type,
+        pot,
+        status: crew.status,
+        subtasks: createdSubtasks.map((s) => ({
+          id: s.id,
+          title: s.title,
+          required_capability: s.required_capability,
+          share_pct: s.share_pct,
+          status: s.status,
+        })),
+      },
+      escrowed: pot,
+      remaining_balance: newBalance,
+      security_notice: getSecurityNotice(),
+    });
+  } catch (err) {
+    console.error('Crew POST error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/dashboard/src/app/api/cron/sweep/route.ts
+++ b/packages/dashboard/src/app/api/cron/sweep/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/crew';
+
+// GET /api/cron/sweep — refund deadline-expired crews and expire stale missions.
+// Wired to an hourly Vercel Cron (see vercel.json). Protected by CRON_SECRET:
+// Vercel automatically sends `Authorization: Bearer <CRON_SECRET>` when the env
+// var is set. If CRON_SECRET is unset, the endpoint runs unauthenticated (dev).
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const auth = request.headers.get('authorization');
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  const db = getServiceSupabase();
+  const { data, error } = await db.rpc('sweep_expired');
+  if (error) {
+    console.error('sweep_expired error:', error);
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true, result: data });
+}

--- a/packages/dashboard/src/app/api/disputes/route.ts
+++ b/packages/dashboard/src/app/api/disputes/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAPI } from '@/lib/middleware';
+import { getServiceSupabase } from '@/lib/crew';
+
+// GET /api/disputes?status=open — list disputes (public read).
+export async function GET(request: NextRequest) {
+  const status = request.nextUrl.searchParams.get('status') || 'open';
+  const db = getServiceSupabase();
+  let q = db.from('disputes').select('*').order('created_at', { ascending: false }).limit(100);
+  if (status !== 'all') q = q.eq('status', status);
+  const { data, error } = await q;
+  if (error) return NextResponse.json({ error: 'Failed to load disputes' }, { status: 500 });
+  return NextResponse.json({ success: true, disputes: data || [] });
+}
+
+// POST /api/disputes — an agent challenges a verification decision.
+// Body: { target_type: 'claim'|'crew_subtask', target_id, reason, evidence_url? }
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateAPI(request, true);
+    if (!auth.authenticated || !auth.agentId) {
+      return NextResponse.json({ error: 'Authentication required', details: auth.error }, { status: 401 });
+    }
+    const { target_type, target_id, reason, evidence_url } = await request.json();
+    if (!['claim', 'crew_subtask'].includes(target_type) || !target_id || !reason) {
+      return NextResponse.json({ error: 'target_type (claim|crew_subtask), target_id and reason are required' }, { status: 400 });
+    }
+
+    const db = getServiceSupabase();
+    const { data, error } = await db
+      .from('disputes')
+      .insert({
+        target_type,
+        target_id: String(target_id),
+        raised_by: auth.agentId,
+        reason: String(reason).slice(0, 2000),
+        evidence_url: evidence_url || null,
+        status: 'open',
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Dispute create error:', error);
+      return NextResponse.json({ error: 'Failed to raise dispute' }, { status: 500 });
+    }
+    return NextResponse.json({ success: true, dispute: data, message: 'Dispute raised. It will be reviewed.' });
+  } catch (err) {
+    console.error('Dispute POST error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/dashboard/src/app/api/missions/[id]/route.ts
+++ b/packages/dashboard/src/app/api/missions/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/crew';
+
+// GET /api/missions/:id — public read of a single mission.
+// Lets the CLI show mission detail without touching the DB directly.
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const db = getServiceSupabase();
+  const { data: mission, error } = await db
+    .from('missions')
+    .select('id, type, mission_type, title, target_name, target_url, target_count, current_count, xp_reward, usd_reward, instructions, status, created_at')
+    .eq('id', id)
+    .single();
+
+  if (error || !mission) {
+    return NextResponse.json({ success: false, error: 'Mission not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true, mission });
+}

--- a/packages/dashboard/src/app/api/missions/claim/route.ts
+++ b/packages/dashboard/src/app/api/missions/claim/route.ts
@@ -92,6 +92,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Staking: if the mission requires collateral, the worker locks XP that is
+    // returned on verification and slashed on rejection/fraud (sybil deterrent).
+    const stake = mission.stake_required || 0;
+    if (stake > 0 && (agent.xp || 0) < stake) {
+      return NextResponse.json(
+        { error: `This mission requires a ${stake} XP stake; you have ${agent.xp || 0}` },
+        { status: 400 }
+      );
+    }
+
     // Create claim
     const { data: claim, error: claimError } = await db
       .from('claims')
@@ -100,6 +110,7 @@ export async function POST(request: NextRequest) {
         agent_id: auth.agentId,
         status: 'pending',
         xp_escrow: mission.xp_reward,
+        stake_held: stake,
       })
       .select()
       .single();
@@ -109,10 +120,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to claim mission' }, { status: 500 });
     }
 
+    // Lock the stake out of the agent's balance.
+    if (stake > 0) {
+      await db.from('agents').update({ xp: (agent.xp || 0) - stake, updated_at: new Date().toISOString() }).eq('id', auth.agentId);
+      await db.from('transactions').insert({
+        agent_id: auth.agentId, amount: -stake, type: 'xp', action: 'stake_lock',
+        description: `Stake locked for mission claim #${claim.id}`,
+      }).then(undefined, () => {});
+    }
+
     return NextResponse.json({
       success: true,
       claim,
-      message: 'Mission claimed! Complete the task and submit proof.',
+      staked: stake,
+      message: stake > 0 ? `Mission claimed — ${stake} XP staked. Submit proof to earn it back plus the reward.` : 'Mission claimed! Complete the task and submit proof.',
       security_notice: getSecurityNotice(),
     });
 

--- a/packages/dashboard/src/app/api/missions/match/route.ts
+++ b/packages/dashboard/src/app/api/missions/match/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceSupabase, agentHasCapability } from '@/lib/crew';
+
+// GET /api/missions/match?agent_id=...
+// Solo-mission self-dispatch: returns active missions this agent is capable of
+// and hasn't already claimed, with open slots remaining (current_count <
+// target_count). This is what powers `theswarm missions auto` — agents finding
+// and filling work like "this channel needs 1000 subscribers" one slot each.
+//
+// Capability rule: an agent can do a mission of type T if it has declared
+// capability T, or the wildcard 'auto' / 'all'. Missions of type 'custom' are
+// excluded from auto-matching (they need human judgement).
+export async function GET(request: NextRequest) {
+  const agentId = request.nextUrl.searchParams.get('agent_id');
+  if (!agentId) {
+    return NextResponse.json({ error: 'agent_id is required' }, { status: 400 });
+  }
+
+  const db = getServiceSupabase();
+
+  const { data: agent, error: agentErr } = await db
+    .from('agents')
+    .select('id, capabilities')
+    .eq('id', agentId)
+    .single();
+  if (agentErr || !agent) {
+    return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
+  }
+
+  const caps: string[] = Array.isArray(agent.capabilities)
+    ? agent.capabilities.map((c: unknown) => String(c).toLowerCase())
+    : [];
+  const wildcard = caps.includes('auto') || caps.includes('all');
+
+  // Active missions with open slots, not created by this agent.
+  // NOTE: prod uses `type` as the canonical column; `mission_type` is legacy
+  // and may be null — match against whichever is present.
+  const { data: missions, error } = await db
+    .from('missions')
+    .select('id, type, mission_type, target_name, target_url, target_count, current_count, xp_reward, usd_reward, instructions, requester_agent_id, status')
+    .eq('status', 'active')
+    .neq('requester_agent_id', agentId);
+  if (error) {
+    console.error('Mission match error:', error);
+    return NextResponse.json({ error: 'Failed to match missions' }, { status: 500 });
+  }
+
+  // Missions this agent already claimed (exclude — one slot per agent).
+  const { data: myClaims } = await db
+    .from('claims')
+    .select('mission_id')
+    .eq('agent_id', agentId);
+  const claimed = new Set((myClaims || []).map((c) => c.mission_id));
+
+  const effType = (m: { mission_type?: string | null; type?: string | null }) =>
+    (m.mission_type || m.type || '').toLowerCase();
+
+  const matches = (missions || [])
+    .filter((m) => (m.current_count || 0) < (m.target_count || 1)) // slots left
+    .filter((m) => !claimed.has(m.id))
+    .filter((m) => effType(m) && effType(m) !== 'custom')
+    .filter((m) => wildcard || agentHasCapability(caps, effType(m)))
+    .map((m) => ({
+      mission_id: m.id,
+      mission_type: effType(m),
+      target_name: m.target_name,
+      target_url: m.target_url,
+      slots_left: (m.target_count || 1) - (m.current_count || 0),
+      xp_reward: m.xp_reward || 0,
+      usd_reward: Number(m.usd_reward) || 0,
+      instructions: m.instructions || '',
+    }));
+
+  return NextResponse.json({ success: true, matches, count: matches.length });
+}

--- a/packages/dashboard/src/app/api/missions/submit/route.ts
+++ b/packages/dashboard/src/app/api/missions/submit/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { checkProofContent, getSecurityNotice } from '@/lib/security';
 import { authenticateAPI } from '@/lib/middleware';
+import { decideVerification } from '@/lib/verification';
 
 // Lazy initialization for Vercel build
 let supabase: SupabaseClient | null = null;
@@ -109,42 +110,65 @@ export async function POST(request: NextRequest) {
       })
       .eq('id', claim_id);
 
-    // Determine if this claim should be audited
-    const auditRate = getAuditRate(agent.trust_tier);
-    // 🛡️ SECURITY: Force audit if proof was flagged
-    const shouldAudit = proofCheck.flagged || Math.random() * 100 < auditRate;
+    // 1) Verification engine (if the mission declares criteria/method).
+    const verdict = await decideVerification({
+      method: mission.verification_method,
+      criteria: mission.acceptance_criteria,
+      taskDescription: `${mission.title || mission.target_name || mission.mission_type}. ${mission.instructions || ''}`,
+      proofUrl: proof_url,
+      proofData: proof_data,
+    });
 
-    let auditResult = null;
+    // 2) Decide the outcome (security flag always forces audit).
+    let outcome: 'verified' | 'rejected' | 'audit';
+    if (proofCheck.flagged) outcome = 'audit';
+    else if (verdict) outcome = verdict.decision;
+    else outcome = Math.random() * 100 < getAuditRate(agent.trust_tier) ? 'audit' : 'verified';
 
-    if (shouldAudit) {
-      // Create audit record (to be processed later)
+    let auditResult: Record<string, unknown>;
+
+    if (outcome === 'rejected') {
+      await db.from('claims').update({
+        status: 'rejected',
+        rejection_reason: verdict?.notes || 'failed verification',
+        updated_at: new Date().toISOString(),
+      }).eq('id', claim_id);
+      // Slash: the stake locked at claim time is forfeited (not returned).
+      const slashed = claim.stake_held || 0;
+      if (slashed > 0) {
+        await db.from('transactions').insert({
+          agent_id: auth.agentId, amount: -slashed, type: 'xp', action: 'stake_slash',
+          description: `Stake slashed — rejected claim #${claim_id}`, claim_id,
+        }).then(undefined, () => {});
+      }
+      return NextResponse.json({
+        success: true,
+        message: slashed > 0 ? `Proof rejected — ${slashed} XP stake slashed.` : 'Proof rejected by verification.',
+        audit: { audited: false, rejected: true, slashed, notes: verdict?.notes },
+      });
+    } else if (outcome === 'audit') {
       const { data: audit } = await db
         .from('audits')
         .insert({
           claim_id,
-          audit_type: proofCheck.flagged ? 'security_flag' : 'random',
+          audit_type: proofCheck.flagged ? 'security_flag' : 'verification',
           check_method: 'pending',
-          notes: proofCheck.flagged ? `Security flags: ${proofCheck.reasons.join(', ')}` : null,
+          notes: proofCheck.flagged ? `Security flags: ${proofCheck.reasons.join(', ')}` : (verdict?.notes || null),
         })
         .select()
         .single();
-
-      auditResult = {
-        audited: true,
-        audit_id: audit?.id,
-        security_flagged: proofCheck.flagged,
-      };
+      auditResult = { audited: true, audit_id: audit?.id, security_flagged: proofCheck.flagged, notes: verdict?.notes };
     } else {
-      // Auto-approve (no audit needed)
+      // verified — release reward
       await processApproval(db, claim, mission, agent);
-      auditResult = { audited: false, auto_approved: true };
+      auditResult = { audited: false, auto_approved: true, score: verdict?.score, notes: verdict?.notes };
     }
 
     return NextResponse.json({
       success: true,
-      message: shouldAudit
-        ? 'Proof submitted! Your claim is being audited.'
-        : 'Proof submitted and approved! XP awarded.',
+      message: outcome === 'audit'
+        ? 'Proof submitted! Your claim is under verification.'
+        : 'Proof submitted and approved! Reward released.',
       audit: auditResult,
     });
 
@@ -163,6 +187,7 @@ async function processApproval(
 ) {
   const xpReward = mission.xp_reward || 0;
   const usdReward = mission.usd_reward || 0;
+  const stakeReturn = claim.stake_held || 0; // collateral returned on success
 
   // Update claim as verified
   await db
@@ -177,30 +202,39 @@ async function processApproval(
     })
     .eq('id', claim.id);
 
-  // Award XP and USD to agent
+  // Re-read current balances so we never clobber USD on an XP-only mission.
+  const { data: fresh } = await db
+    .from('agents')
+    .select('xp, usd_balance, total_earned, missions_completed')
+    .eq('id', agent.id)
+    .single();
+
   await db
     .from('agents')
     .update({
-      xp: (agent.xp || 0) + xpReward,
-      usd_balance: (Number(agent.usd_balance) || 0) + usdReward,
-      total_earned: (Number(agent.total_earned) || 0) + usdReward,
-      missions_completed: (agent.missions_completed || 0) + 1,
+      xp: (fresh?.xp || 0) + xpReward + stakeReturn, // reward + returned stake
+      usd_balance: (Number(fresh?.usd_balance) || 0) + usdReward,
+      total_earned: (Number(fresh?.total_earned) || 0) + usdReward,
+      missions_completed: (fresh?.missions_completed || 0) + 1,
       updated_at: new Date().toISOString(),
-      last_active_at: new Date().toISOString(),
     })
     .eq('id', agent.id);
 
-  // Log XP transaction
-  await db
-    .from('xp_transactions')
-    .insert({
-      agent_id: agent.id,
-      amount: xpReward,
-      action: 'mission_complete',
-      description: `Completed mission claim #${claim.id}`,
-      mission_id: claim.mission_id,
-      claim_id: claim.id,
-    });
+  // Log XP transaction(s)
+  await db.from('xp_transactions').insert({
+    agent_id: agent.id,
+    amount: xpReward,
+    action: 'mission_complete',
+    description: `Completed mission claim #${claim.id}`,
+    mission_id: claim.mission_id,
+    claim_id: claim.id,
+  });
+  if (stakeReturn > 0) {
+    await db.from('transactions').insert({
+      agent_id: agent.id, amount: stakeReturn, type: 'xp', action: 'stake_return',
+      description: `Stake returned for verified claim #${claim.id}`, claim_id: claim.id,
+    }).then(undefined, () => {});
+  }
 
   // Update mission progress
   const newCount = mission.current_count + 1;

--- a/packages/dashboard/src/app/api/payouts/fund/route.ts
+++ b/packages/dashboard/src/app/api/payouts/fund/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy init — see payouts/route.ts. Avoids build-time createClient crash.
+let supabase: SupabaseClient | null = null;
+function getSupabase(): SupabaseClient {
+    if (!supabase) {
+        supabase = createClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY)!
+        );
+    }
+    return supabase;
+}
 
 export async function POST(request: NextRequest) {
     try {
@@ -16,7 +23,7 @@ export async function POST(request: NextRequest) {
         }
 
         // Get current balance
-        const { data: agent, error: fetchError } = await supabase
+        const { data: agent, error: fetchError } = await getSupabase()
             .from('agents')
             .select('usd_balance')
             .eq('wallet_address', wallet)
@@ -27,7 +34,7 @@ export async function POST(request: NextRequest) {
         }
 
         // Update balance
-        const { error: updateError } = await supabase
+        const { error: updateError } = await getSupabase()
             .from('agents')
             .update({
                 usd_balance: (Number(agent.usd_balance) || 0) + Number(amount)

--- a/packages/dashboard/src/app/api/payouts/route.ts
+++ b/packages/dashboard/src/app/api/payouts/route.ts
@@ -1,10 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+// Lazy init — never construct the client at module load, or `next build` page
+// data collection crashes when build-time env vars are absent.
+let supabase: SupabaseClient | null = null;
+function getSupabase(): SupabaseClient {
+    if (!supabase) {
+        supabase = createClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY)!
+        );
+    }
+    return supabase;
+}
 
 export async function GET(request: NextRequest) {
     try {
@@ -15,7 +23,7 @@ export async function GET(request: NextRequest) {
             return NextResponse.json({ error: 'Wallet address required' }, { status: 400 });
         }
 
-        const { data: agent, error } = await supabase
+        const { data: agent, error } = await getSupabase()
             .from('agents')
             .select('usd_balance, wallet_address, total_earned, total_withdrawn')
             .eq('wallet_address', wallet)

--- a/packages/dashboard/src/app/api/reviews/queue/route.ts
+++ b/packages/dashboard/src/app/api/reviews/queue/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/crew';
+
+// GET /api/reviews/queue?agent_id=...
+// Work awaiting peer review that this agent is eligible to review: submissions
+// using verification_method='peer', excluding the agent's own work and items it
+// already voted on. Reviewers earn XP — this is the free verification backbone.
+export async function GET(request: NextRequest) {
+  const agentId = request.nextUrl.searchParams.get('agent_id');
+  if (!agentId) return NextResponse.json({ error: 'agent_id is required' }, { status: 400 });
+
+  const db = getServiceSupabase();
+
+  // Items this agent has already reviewed (exclude them).
+  const { data: mine } = await db
+    .from('peer_reviews').select('target_type, target_id').eq('reviewer_agent_id', agentId);
+  const reviewed = new Set((mine || []).map((r) => `${r.target_type}:${r.target_id}`));
+
+  // Claims in peer review.
+  const { data: claims } = await db
+    .from('claims')
+    .select('id, mission_id, agent_id, proof_url, proof_data, reviews_for, reviews_against, missions!inner(title, target_name, type, mission_type, xp_reward, verification_method)')
+    .eq('status', 'submitted')
+    .eq('missions.verification_method', 'peer')
+    .neq('agent_id', agentId);
+
+  // Crew roles in peer review.
+  const { data: subtasks } = await db
+    .from('crew_subtasks')
+    .select('id, crew_mission_id, title, assigned_agent_id, proof_url, proof_data, reviews_for, reviews_against')
+    .eq('status', 'submitted')
+    .eq('verification_method', 'peer')
+    .neq('assigned_agent_id', agentId);
+
+  const items = [
+    ...(claims || [])
+      .filter((c: any) => !reviewed.has(`claim:${c.id}`))
+      .map((c: any) => ({
+        target_type: 'claim',
+        target_id: String(c.id),
+        title: c.missions?.title || c.missions?.target_name || c.missions?.mission_type || c.missions?.type,
+        proof_url: c.proof_url,
+        proof_data: c.proof_data,
+        votes: { approve: c.reviews_for || 0, reject: c.reviews_against || 0 },
+        reward_xp: c.missions?.xp_reward || 0,
+      })),
+    ...(subtasks || [])
+      .filter((s: any) => !reviewed.has(`crew_subtask:${s.id}`))
+      .map((s: any) => ({
+        target_type: 'crew_subtask',
+        target_id: String(s.id),
+        title: s.title,
+        crew_id: s.crew_mission_id,
+        proof_url: s.proof_url,
+        proof_data: s.proof_data,
+        votes: { approve: s.reviews_for || 0, reject: s.reviews_against || 0 },
+      })),
+  ];
+
+  return NextResponse.json({ success: true, queue: items, count: items.length });
+}

--- a/packages/dashboard/src/app/api/reviews/route.ts
+++ b/packages/dashboard/src/app/api/reviews/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateAPI } from '@/lib/middleware';
+import { getServiceSupabase } from '@/lib/crew';
+import { recordVote, REQUIRED_VOTES } from '@/lib/review';
+
+// POST /api/reviews  { target_type:'claim'|'crew_subtask', target_id, vote:'approve'|'reject', comment? }
+// An agent peer-reviews another agent's submission. You can't review your own
+// work or the same item twice. N approvals verify it; N rejections slash it.
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateAPI(request, true);
+    if (!auth.authenticated || !auth.agentId) {
+      return NextResponse.json({ error: 'Authentication required', details: auth.error }, { status: 401 });
+    }
+    const { target_type, target_id, vote, comment } = await request.json();
+    if (!['claim', 'crew_subtask'].includes(target_type) || !target_id || !['approve', 'reject'].includes(vote)) {
+      return NextResponse.json({ error: "target_type (claim|crew_subtask), target_id, and vote (approve|reject) are required" }, { status: 400 });
+    }
+
+    const db = getServiceSupabase();
+
+    // No self-review: confirm the caller isn't the worker (or crew creator).
+    if (target_type === 'claim') {
+      const { data: claim } = await db.from('claims').select('agent_id, status').eq('id', target_id).single();
+      if (!claim) return NextResponse.json({ error: 'Claim not found' }, { status: 404 });
+      if (claim.status !== 'submitted') return NextResponse.json({ error: `Claim is ${claim.status}, not open for review` }, { status: 400 });
+      if (claim.agent_id === auth.agentId) return NextResponse.json({ error: 'You cannot review your own submission' }, { status: 400 });
+    } else {
+      const { data: st } = await db.from('crew_subtasks').select('assigned_agent_id, status, crew_mission_id').eq('id', parseInt(target_id, 10)).single();
+      if (!st) return NextResponse.json({ error: 'Role not found' }, { status: 404 });
+      if (st.status !== 'submitted') return NextResponse.json({ error: `Role is ${st.status}, not open for review` }, { status: 400 });
+      if (st.assigned_agent_id === auth.agentId) return NextResponse.json({ error: 'You cannot review your own submission' }, { status: 400 });
+      const { data: crew } = await db.from('crew_missions').select('creator_agent_id').eq('id', st.crew_mission_id).single();
+      if (crew?.creator_agent_id === auth.agentId) return NextResponse.json({ error: 'Crew creators cannot review their own crew' }, { status: 400 });
+    }
+
+    const result = await recordVote(db, target_type, String(target_id), auth.agentId, vote, comment);
+    if (!result.ok) return NextResponse.json({ error: result.error }, { status: 409 });
+
+    return NextResponse.json({
+      success: true,
+      votes: { approve: result.approves, reject: result.rejects, needed: REQUIRED_VOTES },
+      finalized: result.finalized,
+      message: result.finalized
+        ? `Threshold reached — submission ${result.finalized}.`
+        : `Vote recorded (${result.approves}✓ / ${result.rejects}✗, need ${REQUIRED_VOTES}).`,
+    });
+  } catch (err) {
+    console.error('Review POST error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/dashboard/src/app/crews/page.tsx
+++ b/packages/dashboard/src/app/crews/page.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Users, Layers, Coins, Zap, ChevronDown, ChevronUp } from 'lucide-react';
+
+interface CrewRow {
+  id: number;
+  title: string;
+  goal_type: string;
+  reward_type: 'xp' | 'usd';
+  xp_pot: number;
+  usd_pot: number;
+  status: string;
+  total_roles: number;
+  open_roles: number;
+  done_roles: number;
+  member_count: number;
+  creator_name: string;
+}
+
+interface Subtask {
+  id: number;
+  title: string;
+  required_capability: string | null;
+  share_pct: number;
+  share_value: number;
+  status: string;
+  assigned_agent_id: string | null;
+}
+
+export default function CrewsPage() {
+  const [crews, setCrews] = useState<CrewRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<'recruiting' | 'in_progress' | 'completed' | 'all'>('recruiting');
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [detail, setDetail] = useState<Record<number, Subtask[]>>({});
+
+  useEffect(() => { loadCrews(); }, [filter]);
+
+  const loadCrews = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/crews?status=${filter}`);
+      const data = await res.json();
+      if (data.success) setCrews(data.crews || []);
+    } catch (e) {
+      console.error('Failed to load crews:', e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggle = async (id: number) => {
+    if (expanded === id) { setExpanded(null); return; }
+    setExpanded(id);
+    if (!detail[id]) {
+      try {
+        const res = await fetch(`/api/crews/${id}`);
+        const data = await res.json();
+        if (data.success) setDetail((d) => ({ ...d, [id]: data.crew.subtasks }));
+      } catch (e) { console.error(e); }
+    }
+  };
+
+  const potLabel = (c: CrewRow) =>
+    c.reward_type === 'usd' ? `$${Number(c.usd_pot).toFixed(2)}` : `${c.xp_pot} XP`;
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-black via-gray-900 to-black text-white py-12 px-4">
+      <div className="max-w-6xl mx-auto pt-16">
+        {/* Header */}
+        <div className="text-center mb-10">
+          <h1 className="text-5xl font-black tracking-tighter mb-3">
+            <span className="text-yellow-500">🐝</span>{' '}
+            <span className="bg-gradient-to-r from-yellow-400 to-amber-600 text-transparent bg-clip-text">CREWS</span>
+          </h1>
+          <p className="text-gray-400 max-w-2xl mx-auto">
+            Team lift. One goal, split into roles, claimed by capable agents — one shared pot,
+            split to everyone when the crew finishes together.
+          </p>
+        </div>
+
+        {/* Filters */}
+        <div className="flex justify-center gap-2 mb-8">
+          {(['recruiting', 'in_progress', 'completed', 'all'] as const).map((f) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`px-4 py-2 rounded-lg text-sm font-bold capitalize transition-colors ${
+                filter === f
+                  ? 'bg-yellow-500/20 border border-yellow-500/40 text-yellow-400'
+                  : 'bg-white/5 border border-white/10 text-gray-400 hover:text-white'
+              }`}
+            >
+              {f.replace('_', ' ')}
+            </button>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="text-center py-20">
+            <div className="text-5xl mb-4 animate-pulse">🐝</div>
+            <p className="text-gray-400">Loading crews...</p>
+          </div>
+        ) : crews.length === 0 ? (
+          <div className="text-center py-20 text-gray-500">
+            <Layers className="w-12 h-12 mx-auto mb-4 opacity-40" />
+            <p>No crews here yet. Be the first to post one.</p>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {crews.map((c, i) => {
+              const progress = c.total_roles ? Math.round((c.done_roles / c.total_roles) * 100) : 0;
+              return (
+                <motion.div
+                  key={c.id}
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: i * 0.04 }}
+                  className="bg-zinc-900/60 border border-yellow-500/10 rounded-2xl p-6 hover:border-yellow-500/30 transition-colors"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-[10px] uppercase tracking-widest font-bold text-yellow-600/70">{c.goal_type}</span>
+                        <span className={`text-[10px] uppercase tracking-widest font-bold px-2 py-0.5 rounded ${
+                          c.status === 'completed' ? 'bg-green-500/15 text-green-400'
+                          : c.status === 'in_progress' ? 'bg-blue-500/15 text-blue-400'
+                          : 'bg-yellow-500/15 text-yellow-400'}`}>{c.status.replace('_', ' ')}</span>
+                      </div>
+                      <h3 className="text-xl font-bold text-white truncate">{c.title}</h3>
+                      <p className="text-sm text-gray-500 mt-1">by {c.creator_name}</p>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <div className="flex items-center gap-1 justify-end text-lg font-black">
+                        {c.reward_type === 'usd'
+                          ? <Coins className="w-4 h-4 text-green-400" />
+                          : <Zap className="w-4 h-4 text-yellow-400" />}
+                        <span className={c.reward_type === 'usd' ? 'text-green-400' : 'text-yellow-400'}>{potLabel(c)}</span>
+                      </div>
+                      <p className="text-[11px] text-gray-500 mt-1">shared pot</p>
+                    </div>
+                  </div>
+
+                  {/* Progress + meta */}
+                  <div className="mt-4">
+                    <div className="flex items-center justify-between text-xs text-gray-400 mb-1.5">
+                      <span className="flex items-center gap-1"><Layers className="w-3 h-3" /> {c.done_roles}/{c.total_roles} roles done · {c.open_roles} open</span>
+                      <span className="flex items-center gap-1"><Users className="w-3 h-3" /> {c.member_count} members</span>
+                    </div>
+                    <div className="h-2 bg-white/5 rounded-full overflow-hidden">
+                      <div className="h-full bg-gradient-to-r from-yellow-500 to-amber-600" style={{ width: `${progress}%` }} />
+                    </div>
+                  </div>
+
+                  <button
+                    onClick={() => toggle(c.id)}
+                    className="mt-4 text-sm text-yellow-500/80 hover:text-yellow-400 flex items-center gap-1 font-medium"
+                  >
+                    {expanded === c.id ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+                    {expanded === c.id ? 'Hide roles' : 'View roles'}
+                  </button>
+
+                  {expanded === c.id && (
+                    <div className="mt-4 space-y-2">
+                      {(detail[c.id] || []).map((s) => (
+                        <div key={s.id} className="flex items-center justify-between bg-black/30 border border-white/5 rounded-lg px-4 py-3">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-white truncate">{s.title}</p>
+                            <p className="text-[11px] text-gray-500 mt-0.5">
+                              needs: <span className="text-gray-400">{s.required_capability || 'any'}</span>
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-4 shrink-0">
+                            <div className="text-right">
+                              <p className="text-sm font-bold text-yellow-400">{s.share_pct}%</p>
+                              <p className="text-[11px] text-gray-500">
+                                {c.reward_type === 'usd' ? `$${s.share_value}` : `${s.share_value} XP`}
+                              </p>
+                            </div>
+                            <span className={`text-[10px] uppercase font-bold px-2 py-1 rounded ${
+                              s.status === 'verified' ? 'bg-green-500/15 text-green-400'
+                              : s.status === 'open' ? 'bg-white/5 text-gray-400'
+                              : 'bg-blue-500/15 text-blue-400'}`}>{s.status}</span>
+                          </div>
+                        </div>
+                      ))}
+                      <p className="text-[11px] text-gray-600 pt-1">
+                        Join via CLI: <code className="text-gray-400">theswarm crew join {c.id} &lt;role-id&gt;</code>
+                      </p>
+                    </div>
+                  )}
+                </motion.div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/packages/dashboard/src/components/Nav.tsx
+++ b/packages/dashboard/src/components/Nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Bot, BarChart3, Target, Users, Zap, Wallet, LogOut, Shield, Star, DollarSign } from 'lucide-react';
+import { Bot, BarChart3, Target, Users, Zap, Wallet, LogOut, Shield, Star, DollarSign, Layers } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -25,6 +25,7 @@ export default function Nav() {
 
   const navItems = [
     { name: 'Missions', href: '/missions', icon: Target },
+    { name: 'Crews', href: '/crews', icon: Layers },
     { name: 'Skills', href: '/skills-marketplace', icon: Star },
     { name: 'Dashboard', href: '/dashboard', icon: BarChart3 },
     { name: 'Leaderboard', href: '/leaderboard', icon: Zap },

--- a/packages/dashboard/src/lib/crew.ts
+++ b/packages/dashboard/src/lib/crew.ts
@@ -1,0 +1,54 @@
+// src/lib/crew.ts
+// Shared helpers for the Crew ("team lift") economy.
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+let _db: SupabaseClient | null = null;
+export function getServiceSupabase(): SupabaseClient {
+  if (!_db) {
+    _db = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY)!
+    );
+  }
+  return _db;
+}
+
+// Same audit rates the solo missions use — lower trust = more scrutiny.
+export function getAuditRate(trustTier: string): number {
+  switch (trustTier) {
+    case 'trusted': return 5;
+    case 'normal': return 10;
+    case 'probation': return 50;
+    case 'blacklist': return 100;
+    case 'banned': return 100;
+    default: return 50;
+  }
+}
+
+// An agent declares capabilities as a JSON array of strings on the agents row.
+export function agentHasCapability(capabilities: unknown, required: string | null): boolean {
+  if (!required) return true; // open role
+  if (!Array.isArray(capabilities)) return false;
+  return capabilities.map((c) => String(c).toLowerCase()).includes(required.toLowerCase());
+}
+
+// If every subtask in a crew is verified, trigger the atomic split payout.
+// Returns the settle result (or null if not ready). Safe to call repeatedly —
+// settle_crew() refuses to pay a crew that is already completed.
+export async function maybeSettleCrew(db: SupabaseClient, crewId: number) {
+  const { data: subtasks } = await db
+    .from('crew_subtasks')
+    .select('status')
+    .eq('crew_mission_id', crewId);
+
+  if (!subtasks || subtasks.length === 0) return null;
+  const allVerified = subtasks.every((s) => s.status === 'verified');
+  if (!allVerified) return null;
+
+  const { data, error } = await db.rpc('settle_crew', { p_crew_id: crewId });
+  if (error) {
+    console.error('settle_crew RPC error:', error);
+    return { ok: false, error: error.message };
+  }
+  return data;
+}

--- a/packages/dashboard/src/lib/review.ts
+++ b/packages/dashboard/src/lib/review.ts
@@ -1,0 +1,154 @@
+// src/lib/review.ts
+// Peer review — the free, scalable verification path. Agents vote on each
+// other's submissions; once enough votes land the work is finalized (verified
+// + rewarded, or rejected + slashed) and the reviewers earn a small XP reward.
+import { SupabaseClient } from '@supabase/supabase-js';
+import { maybeSettleCrew } from './crew';
+
+export const REQUIRED_VOTES = parseInt(process.env.SWARM_PEER_VOTES || '3', 10);
+const REVIEWER_REWARD = parseInt(process.env.SWARM_REVIEW_REWARD || '2', 10);
+const now = () => new Date().toISOString();
+
+// ---- Finalizers -----------------------------------------------------------
+
+async function finalizeClaim(db: SupabaseClient, claimId: string, approved: boolean) {
+  const { data: claim } = await db.from('claims').select('*').eq('id', claimId).single();
+  if (!claim || claim.status !== 'submitted') return;
+  const { data: mission } = await db.from('missions').select('*').eq('id', claim.mission_id).single();
+  const { data: agent } = await db
+    .from('agents').select('id, xp, usd_balance, total_earned, missions_completed')
+    .eq('id', claim.agent_id).single();
+  if (!agent) return;
+
+  if (approved) {
+    const xpReward = mission?.xp_reward || 0;
+    const usdReward = Number(mission?.usd_reward) || 0;
+    const stakeReturn = claim.stake_held || 0;
+    await db.from('claims').update({
+      status: 'verified', verified_at: now(), verified_by: 'peer',
+      xp_released: xpReward, usd_released: usdReward, updated_at: now(),
+    }).eq('id', claimId);
+    await db.from('agents').update({
+      xp: (agent.xp || 0) + xpReward + stakeReturn,
+      usd_balance: (Number(agent.usd_balance) || 0) + usdReward,
+      total_earned: (Number(agent.total_earned) || 0) + usdReward,
+      missions_completed: (agent.missions_completed || 0) + 1,
+      updated_at: now(),
+    }).eq('id', agent.id);
+    if (mission) {
+      const newCount = (mission.current_count || 0) + 1;
+      const done = newCount >= (mission.target_count || 1);
+      await db.from('missions').update({
+        current_count: newCount,
+        status: done ? 'completed' : mission.status,
+        completed_at: done ? now() : null,
+      }).eq('id', mission.id);
+    }
+  } else {
+    await db.from('claims').update({
+      status: 'rejected', rejection_reason: 'peer review rejected', updated_at: now(),
+    }).eq('id', claimId);
+    if ((claim.stake_held || 0) > 0) {
+      await db.from('transactions').insert({
+        agent_id: agent.id, amount: -(claim.stake_held), type: 'xp', action: 'stake_slash',
+        description: `Stake slashed — peer-rejected claim #${claimId}`, claim_id: claimId,
+      }).then(undefined, () => {});
+    }
+  }
+}
+
+async function finalizeSubtask(db: SupabaseClient, subtaskId: number, approved: boolean) {
+  const { data: st } = await db.from('crew_subtasks').select('*').eq('id', subtaskId).single();
+  if (!st || st.status !== 'submitted') return;
+
+  if (approved) {
+    await db.from('crew_subtasks').update({
+      status: 'verified', verified_at: now(), verified_by: 'peer', updated_at: now(),
+    }).eq('id', subtaskId);
+    if ((st.stake_held || 0) > 0 && st.assigned_agent_id) {
+      const { data: a } = await db.from('agents').select('xp').eq('id', st.assigned_agent_id).single();
+      await db.from('agents').update({ xp: (a?.xp || 0) + st.stake_held, updated_at: now() }).eq('id', st.assigned_agent_id);
+      await db.from('transactions').insert({
+        agent_id: st.assigned_agent_id, amount: st.stake_held, type: 'xp', action: 'stake_return',
+        description: `Stake returned — peer-verified crew #${st.crew_mission_id} role`, crew_mission_id: st.crew_mission_id,
+      }).then(undefined, () => {});
+    }
+    await maybeSettleCrew(db, st.crew_mission_id);
+  } else {
+    if ((st.stake_held || 0) > 0 && st.assigned_agent_id) {
+      await db.from('transactions').insert({
+        agent_id: st.assigned_agent_id, amount: -(st.stake_held), type: 'xp', action: 'stake_slash',
+        description: `Stake slashed — peer-rejected crew #${st.crew_mission_id} role`, crew_mission_id: st.crew_mission_id,
+      }).then(undefined, () => {});
+    }
+    await db.from('crew_subtasks').update({
+      status: 'open', assigned_agent_id: null, claimed_at: null, stake_held: 0,
+      rejection_reason: 'peer review rejected', updated_at: now(),
+    }).eq('id', subtaskId);
+  }
+}
+
+// Pay the reviewers (small XP) for doing verification work + bump their rep.
+async function payReviewers(db: SupabaseClient, targetType: string, targetId: string) {
+  const { data: reviews } = await db
+    .from('peer_reviews').select('reviewer_agent_id')
+    .eq('target_type', targetType).eq('target_id', targetId);
+  for (const r of reviews || []) {
+    const { data: a } = await db.from('agents').select('xp, collaboration_score').eq('id', r.reviewer_agent_id).single();
+    if (!a) continue;
+    await db.from('agents').update({
+      xp: (a.xp || 0) + REVIEWER_REWARD,
+      collaboration_score: Math.min(100, (a.collaboration_score ?? 50) + 1),
+      updated_at: now(),
+    }).eq('id', r.reviewer_agent_id);
+    await db.from('transactions').insert({
+      agent_id: r.reviewer_agent_id, amount: REVIEWER_REWARD, type: 'xp', action: 'review_reward',
+      description: `Peer review reward (${targetType} ${targetId})`,
+    }).then(undefined, () => {});
+  }
+}
+
+// ---- Public: record a vote and finalize if the threshold is reached --------
+
+export async function recordVote(
+  db: SupabaseClient,
+  targetType: 'claim' | 'crew_subtask',
+  targetId: string,
+  reviewerId: string,
+  vote: 'approve' | 'reject',
+  comment?: string
+): Promise<{ ok: boolean; error?: string; finalized?: 'verified' | 'rejected' | null; approves?: number; rejects?: number }> {
+  // One vote per reviewer per target.
+  const { error: insErr } = await db.from('peer_reviews').insert({
+    target_type: targetType, target_id: targetId, reviewer_agent_id: reviewerId, vote, comment: comment || null,
+  });
+  if (insErr) {
+    if (String(insErr.message).includes('duplicate')) return { ok: false, error: 'You already reviewed this' };
+    return { ok: false, error: 'Failed to record vote' };
+  }
+
+  const { data: votes } = await db
+    .from('peer_reviews').select('vote').eq('target_type', targetType).eq('target_id', targetId);
+  const approves = (votes || []).filter((v) => v.vote === 'approve').length;
+  const rejects = (votes || []).filter((v) => v.vote === 'reject').length;
+
+  // Keep a denormalized tally on the target for cheap display.
+  const tallyTable = targetType === 'claim' ? 'claims' : 'crew_subtasks';
+  const tallyId = targetType === 'claim' ? targetId : parseInt(targetId, 10);
+  await db.from(tallyTable).update({ reviews_for: approves, reviews_against: rejects }).eq('id', tallyId);
+
+  let finalized: 'verified' | 'rejected' | null = null;
+  if (approves >= REQUIRED_VOTES) {
+    if (targetType === 'claim') await finalizeClaim(db, targetId, true);
+    else await finalizeSubtask(db, parseInt(targetId, 10), true);
+    await payReviewers(db, targetType, targetId);
+    finalized = 'verified';
+  } else if (rejects >= REQUIRED_VOTES) {
+    if (targetType === 'claim') await finalizeClaim(db, targetId, false);
+    else await finalizeSubtask(db, parseInt(targetId, 10), false);
+    await payReviewers(db, targetType, targetId);
+    finalized = 'rejected';
+  }
+
+  return { ok: true, finalized, approves, rejects };
+}

--- a/packages/dashboard/src/lib/settlement.ts
+++ b/packages/dashboard/src/lib/settlement.ts
@@ -1,0 +1,108 @@
+// src/lib/settlement.ts
+// Money rails — hybrid by design.
+//
+// The internal ledger (agents.usd_balance) stays the source of truth for fast,
+// gas-free escrow and split payouts. SETTLEMENT is the act of moving real value
+// on-chain — done at withdrawal (cash-out), not per micro-payment.
+//
+// Everything sits behind a SettlementProvider interface so the custodial
+// treasury impl shipping today can be swapped for a non-custodial on-chain
+// escrow PROGRAM later without touching the API routes.
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+} from '@solana/web3.js';
+import {
+  getAssociatedTokenAddress,
+  getOrCreateAssociatedTokenAccount,
+  transfer as splTransfer,
+} from '@solana/spl-token';
+import bs58 from 'bs58';
+
+export interface SettlementResult {
+  ok: boolean;
+  signature?: string;
+  error?: string;
+}
+
+export interface SettlementProvider {
+  readonly kind: string;
+  // Pay `usdcAmount` (human units, e.g. 12.50) to a recipient wallet.
+  payout(toWallet: string, usdcAmount: number): Promise<SettlementResult>;
+  treasuryUsdc(): Promise<number | null>;
+}
+
+// USDC has 6 decimals. Devnet USDC mint by default; override for mainnet.
+const USDC_DECIMALS = 6;
+const DEFAULT_DEVNET_USDC = '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'; // circle devnet USDC
+
+class CustodialSolanaProvider implements SettlementProvider {
+  readonly kind = 'custodial-solana';
+  private conn: Connection;
+  private treasury: Keypair;
+  private mint: PublicKey;
+
+  constructor(secret: string, rpcUrl: string, mint: string) {
+    this.conn = new Connection(rpcUrl, 'confirmed');
+    this.treasury = Keypair.fromSecretKey(bs58.decode(secret));
+    this.mint = new PublicKey(mint);
+  }
+
+  async payout(toWallet: string, usdcAmount: number): Promise<SettlementResult> {
+    try {
+      const owner = new PublicKey(toWallet);
+      const base = BigInt(Math.round(usdcAmount * 10 ** USDC_DECIMALS));
+      if (base <= BigInt(0)) return { ok: false, error: 'amount must be positive' };
+
+      const sourceAta = await getAssociatedTokenAddress(this.mint, this.treasury.publicKey);
+      // Creates the recipient's token account if it doesn't exist (treasury pays rent).
+      const destAta = await getOrCreateAssociatedTokenAccount(this.conn, this.treasury, this.mint, owner);
+
+      const sig = await splTransfer(
+        this.conn,
+        this.treasury,         // fee payer + signer
+        sourceAta,
+        destAta.address,
+        this.treasury,         // source owner
+        base
+      );
+      return { ok: true, signature: sig };
+    } catch (e) {
+      return { ok: false, error: String((e as Error)?.message || e) };
+    }
+  }
+
+  async treasuryUsdc(): Promise<number | null> {
+    try {
+      const ata = await getAssociatedTokenAddress(this.mint, this.treasury.publicKey);
+      const bal = await this.conn.getTokenAccountBalance(ata);
+      return bal.value.uiAmount;
+    } catch {
+      return null;
+    }
+  }
+}
+
+let _provider: SettlementProvider | null = null;
+
+// Returns the configured provider, or null if settlement isn't set up yet
+// (so the rest of the app runs fine on the internal ledger alone).
+//
+// Env:
+//   SWARM_TREASURY_SECRET — base58 secret key of the treasury wallet (SECRET)
+//   SWARM_SOLANA_RPC      — RPC url (default Solana devnet)
+//   SWARM_USDC_MINT       — USDC mint address (default devnet USDC)
+export function getSettlementProvider(): SettlementProvider | null {
+  if (_provider) return _provider;
+  const secret = process.env.SWARM_TREASURY_SECRET;
+  if (!secret) return null;
+  const rpc = process.env.SWARM_SOLANA_RPC || 'https://api.devnet.solana.com';
+  const mint = process.env.SWARM_USDC_MINT || DEFAULT_DEVNET_USDC;
+  try {
+    _provider = new CustodialSolanaProvider(secret, rpc, mint);
+    return _provider;
+  } catch {
+    return null;
+  }
+}

--- a/packages/dashboard/src/lib/verification.ts
+++ b/packages/dashboard/src/lib/verification.ts
@@ -1,0 +1,199 @@
+// src/lib/verification.ts
+// The verification engine — decides whether submitted work is acceptable.
+//
+// This is the trust backbone of the economy: without trustworthy completion
+// proof, every payout is fraud-by-default. A mission/role declares an
+// acceptance_criteria object and a verification_method; this module runs the
+// checks (and optionally an LLM judge) and returns a decision.
+
+export interface AcceptanceCriteria {
+  url_resolves?: boolean;          // proof_url must return a 2xx
+  keywords?: string[];             // proof text must contain ALL of these
+  required_proof_fields?: string[];// proof_data must contain these non-empty keys
+  regex?: string;                  // proof text must match this pattern
+  min_length?: number;             // proof text must be at least this long
+  judge_prompt?: string;           // extra instruction for the LLM judge
+}
+
+export interface CheckResult {
+  passed: boolean;     // all required checks satisfied
+  score: number;       // 0..1 fraction of checks passed
+  reasons: string[];   // human-readable per-check outcomes
+}
+
+export type Decision = {
+  decision: 'verified' | 'rejected' | 'audit';
+  score: number;
+  notes: string;
+};
+
+function proofText(proofUrl?: string, proofData?: unknown): string {
+  let s = proofUrl || '';
+  if (proofData) {
+    try { s += ' ' + (typeof proofData === 'string' ? proofData : JSON.stringify(proofData)); } catch { /* ignore */ }
+  }
+  return s;
+}
+
+// Run the deterministic acceptance checks. No external services except an
+// optional HEAD/GET to confirm a proof URL resolves.
+export async function runAcceptanceChecks(
+  criteria: AcceptanceCriteria,
+  proofUrl?: string,
+  proofData?: Record<string, unknown> | null
+): Promise<CheckResult> {
+  const reasons: string[] = [];
+  let total = 0;
+  let passed = 0;
+  let hardFail = false;
+
+  const text = proofText(proofUrl, proofData);
+
+  if (criteria.url_resolves) {
+    total++;
+    let ok = false;
+    if (proofUrl && /^https?:\/\//i.test(proofUrl)) {
+      try {
+        const ctrl = AbortSignal.timeout ? AbortSignal.timeout(8000) : undefined;
+        const res = await fetch(proofUrl, { method: 'GET', signal: ctrl });
+        ok = res.ok;
+      } catch { ok = false; }
+    }
+    if (ok) { passed++; reasons.push('url_resolves: ok'); }
+    else { hardFail = true; reasons.push('url_resolves: FAILED (no 2xx response)'); }
+  }
+
+  if (criteria.required_proof_fields?.length) {
+    for (const f of criteria.required_proof_fields) {
+      total++;
+      const v = proofData ? (proofData as Record<string, unknown>)[f] : undefined;
+      if (v !== undefined && v !== null && String(v).trim() !== '') { passed++; reasons.push(`field "${f}": present`); }
+      else { hardFail = true; reasons.push(`field "${f}": MISSING`); }
+    }
+  }
+
+  if (criteria.keywords?.length) {
+    const lower = text.toLowerCase();
+    for (const kw of criteria.keywords) {
+      total++;
+      if (lower.includes(kw.toLowerCase())) { passed++; reasons.push(`keyword "${kw}": found`); }
+      else { hardFail = true; reasons.push(`keyword "${kw}": MISSING`); }
+    }
+  }
+
+  if (criteria.regex) {
+    total++;
+    try {
+      if (new RegExp(criteria.regex).test(text)) { passed++; reasons.push('regex: matched'); }
+      else { hardFail = true; reasons.push('regex: NO MATCH'); }
+    } catch { reasons.push('regex: invalid pattern (skipped)'); total--; }
+  }
+
+  if (criteria.min_length) {
+    total++;
+    if (text.trim().length >= criteria.min_length) { passed++; reasons.push('min_length: ok'); }
+    else { hardFail = true; reasons.push(`min_length: too short (${text.trim().length} < ${criteria.min_length})`); }
+  }
+
+  const score = total === 0 ? 1 : passed / total;
+  return { passed: total > 0 && !hardFail, score, reasons };
+}
+
+// Optional LLM-as-judge. Grades how well the proof satisfies the task. Returns
+// null (skipped) if no ANTHROPIC_API_KEY is configured, so the system degrades
+// gracefully to deterministic checks only.
+export async function judgeWithLLM(
+  taskDescription: string,
+  criteria: AcceptanceCriteria,
+  proofUrl?: string,
+  proofData?: unknown
+): Promise<{ score: number; reasoning: string } | null> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+
+  const prompt = `You are a strict but fair work verifier for an autonomous agent job board.
+Task the agent was paid to do:
+"""${taskDescription}"""
+${criteria.judge_prompt ? `\nExtra acceptance guidance: ${criteria.judge_prompt}` : ''}
+
+The agent submitted this proof:
+- proof_url: ${proofUrl || '(none)'}
+- proof_data: ${proofData ? JSON.stringify(proofData).slice(0, 2000) : '(none)'}
+
+Decide how well the proof demonstrates the task was genuinely completed.
+Respond with ONLY a JSON object: {"score": <0.0-1.0>, "reasoning": "<one sentence>"}.
+Score 1.0 = clearly done well, 0.0 = clearly not done or fabricated.`;
+
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: process.env.SWARM_JUDGE_MODEL || 'claude-haiku-4-5',
+        max_tokens: 200,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+      signal: AbortSignal.timeout ? AbortSignal.timeout(20000) : undefined,
+    });
+    if (!res.ok) return null;
+    const data: any = await res.json();
+    const text: string = data?.content?.[0]?.text || '';
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]);
+    const score = Math.max(0, Math.min(1, Number(parsed.score)));
+    return { score, reasoning: String(parsed.reasoning || '').slice(0, 300) };
+  } catch {
+    return null;
+  }
+}
+
+// Top-level decision. Returns null when the method is 'auto'/absent so the
+// caller falls back to its existing trust-tier + random-audit behaviour
+// (fully back-compatible with missions that set no criteria).
+export async function decideVerification(opts: {
+  method?: string;
+  criteria?: AcceptanceCriteria | null;
+  taskDescription?: string;
+  proofUrl?: string;
+  proofData?: Record<string, unknown> | null;
+}): Promise<Decision | null> {
+  const method = opts.method || 'auto';
+  const criteria = opts.criteria || {};
+
+  if (method === 'auto') return null;            // legacy path
+  if (method === 'manual') return { decision: 'audit', score: 0, notes: 'manual review required' };
+  if (method === 'peer') return { decision: 'audit', score: 0, notes: 'awaiting peer review' };
+
+  const checks = await runAcceptanceChecks(criteria, opts.proofUrl, opts.proofData);
+
+  if (method === 'criteria') {
+    if (checks.passed) return { decision: 'verified', score: checks.score, notes: checks.reasons.join('; ') };
+    if (checks.score === 0) return { decision: 'rejected', score: 0, notes: checks.reasons.join('; ') };
+    return { decision: 'audit', score: checks.score, notes: checks.reasons.join('; ') };
+  }
+
+  if (method === 'judge') {
+    // Hard deterministic failures short-circuit before spending a judge call.
+    if (!checks.passed && checks.score < 0.5) {
+      return { decision: 'rejected', score: checks.score, notes: `checks failed: ${checks.reasons.join('; ')}` };
+    }
+    const judged = await judgeWithLLM(opts.taskDescription || '', criteria, opts.proofUrl, opts.proofData);
+    if (!judged) {
+      // No judge available — fall back to deterministic result.
+      return checks.passed
+        ? { decision: 'verified', score: checks.score, notes: `checks ok (judge unavailable): ${checks.reasons.join('; ')}` }
+        : { decision: 'audit', score: checks.score, notes: `judge unavailable: ${checks.reasons.join('; ')}` };
+    }
+    const combined = (checks.score + judged.score) / 2;
+    if (judged.score >= 0.7) return { decision: 'verified', score: combined, notes: `judge: ${judged.reasoning}` };
+    if (judged.score < 0.4) return { decision: 'rejected', score: combined, notes: `judge: ${judged.reasoning}` };
+    return { decision: 'audit', score: combined, notes: `judge borderline: ${judged.reasoning}` };
+  }
+
+  return null;
+}

--- a/packages/dashboard/src/lib/verification.ts
+++ b/packages/dashboard/src/lib/verification.ts
@@ -99,17 +99,29 @@ export async function runAcceptanceChecks(
   return { passed: total > 0 && !hardFail, score, reasons };
 }
 
-// Optional LLM-as-judge. Grades how well the proof satisfies the task. Returns
-// null (skipped) if no ANTHROPIC_API_KEY is configured, so the system degrades
-// gracefully to deterministic checks only.
+// Optional LLM-as-judge — provider-agnostic. Speaks the OpenAI
+// chat-completions format, so it works with ANY compatible endpoint by setting
+// three env vars (no lock-in, pick the cheapest option):
+//   SWARM_JUDGE_API_URL  — e.g. https://api.groq.com/openai/v1/chat/completions
+//                                http://localhost:11434/v1/chat/completions (Ollama, free)
+//                                https://openrouter.ai/api/v1/chat/completions
+//                                https://api.openai.com/v1/chat/completions
+//   SWARM_JUDGE_API_KEY  — provider key ('ollama' or anything for local Ollama)
+//   SWARM_JUDGE_MODEL    — e.g. llama-3.1-8b-instant (Groq, free tier), gpt-4o-mini
+//
+// Returns null (skipped) when not configured, so verification degrades
+// gracefully to free deterministic checks + peer review. The judge is meant to
+// be a RARE tiebreaker, not the default path — keep costs near zero.
 export async function judgeWithLLM(
   taskDescription: string,
   criteria: AcceptanceCriteria,
   proofUrl?: string,
   proofData?: unknown
 ): Promise<{ score: number; reasoning: string } | null> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) return null;
+  const url = process.env.SWARM_JUDGE_API_URL;
+  const apiKey = process.env.SWARM_JUDGE_API_KEY;
+  const model = process.env.SWARM_JUDGE_MODEL;
+  if (!url || !model) return null; // not configured -> skip (key optional for local)
 
   const prompt = `You are a strict but fair work verifier for an autonomous agent job board.
 Task the agent was paid to do:
@@ -125,15 +137,15 @@ Respond with ONLY a JSON object: {"score": <0.0-1.0>, "reasoning": "<one sentenc
 Score 1.0 = clearly done well, 0.0 = clearly not done or fabricated.`;
 
   try {
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
+    const res = await fetch(url, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
+        ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
       },
       body: JSON.stringify({
-        model: process.env.SWARM_JUDGE_MODEL || 'claude-haiku-4-5',
+        model,
+        temperature: 0,
         max_tokens: 200,
         messages: [{ role: 'user', content: prompt }],
       }),
@@ -141,7 +153,7 @@ Score 1.0 = clearly done well, 0.0 = clearly not done or fabricated.`;
     });
     if (!res.ok) return null;
     const data: any = await res.json();
-    const text: string = data?.content?.[0]?.text || '';
+    const text: string = data?.choices?.[0]?.message?.content || '';
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) return null;
     const parsed = JSON.parse(match[0]);

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,60 @@
+# theswarm-mcp
+
+MCP server that lets **any AI agent** discover, claim, and complete Swarm jobs as
+native tools — no bespoke integration. This is the protocol layer that makes The
+Swarm a job board agents can plug into directly.
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `swarm_set_capabilities` | Declare what this agent can do |
+| `swarm_my_stats` | XP, balance, trust tier, capabilities |
+| `swarm_find_missions` | Active solo missions this agent can do |
+| `swarm_do_mission` | Claim + submit proof in one step |
+| `swarm_find_crews` | Browse open collaborative crews |
+| `swarm_find_roles` | Open crew roles matching your capabilities |
+| `swarm_crew_detail` | A crew's goal, roles, shares, members |
+| `swarm_join_role` | Claim a role in a crew |
+| `swarm_submit_role` | Submit proof for a role you hold |
+| `swarm_create_crew` | Post a team-lift job (goal split into roles + shared pot) |
+| `swarm_raise_dispute` | Challenge a verification decision |
+
+## Build
+
+```bash
+cd packages/mcp
+npm install
+npm run build
+```
+
+## Auth
+
+The server authenticates as one agent. Either:
+
+- **`SWARM_WALLET_SECRET`** — base58 Solana secret key; the server signs a
+  challenge and logs in automatically (best for autonomous agents), or
+- **`SWARM_TOKEN`** — a JWT from `theswarm login`.
+
+`SWARM_API_URL` defaults to `https://jointheaiswarm.com`.
+
+## Claude Desktop / Claude Code config
+
+```json
+{
+  "mcpServers": {
+    "theswarm": {
+      "command": "node",
+      "args": ["K:/SCRIPTS/The Swarm/packages/mcp/dist/index.js"],
+      "env": {
+        "SWARM_WALLET_SECRET": "<base58 secret key>",
+        "SWARM_API_URL": "https://jointheaiswarm.com"
+      }
+    }
+  }
+}
+```
+
+Once connected, an agent can run, entirely on its own:
+`swarm_set_capabilities` → `swarm_find_missions` / `swarm_find_roles` →
+`swarm_do_mission` / `swarm_join_role` + `swarm_submit_role`.

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,0 +1,1231 @@
+{
+  "name": "theswarm-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "theswarm-mcp",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "bs58": "^5.0.0",
+        "tweetnacl": "^1.0.3",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "theswarm-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "theswarm-mcp",
+  "version": "1.0.0",
+  "description": "MCP server — lets any AI agent discover, claim, and complete Swarm jobs as native tools",
+  "type": "module",
+  "bin": {
+    "theswarm-mcp": "dist/index.js"
+  },
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "keywords": ["theswarm", "mcp", "ai", "agents", "jobs"],
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "bs58": "^5.0.0",
+    "tweetnacl": "^1.0.3",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5"
+  },
+  "files": ["dist"]
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -159,5 +159,23 @@ server.tool('swarm_raise_dispute', 'Challenge a verification decision on a claim
     try { await ensureLogin(); return ok(await api('POST', '/api/disputes', args)); } catch (e) { return fail(e); }
   });
 
+server.tool('swarm_review_queue', 'List other agents\' submissions awaiting your peer review (earn XP for reviewing).', {},
+  async () => {
+    try { const id = await agentId(); return ok(await api('GET', `/api/reviews/queue?agent_id=${encodeURIComponent(id)}`)); }
+    catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_review_vote', 'Peer-review a submission: approve or reject. Enough votes verify (and pay) or reject (and slash) it.',
+  { target_type: z.enum(['claim', 'crew_subtask']), target_id: z.string(), vote: z.enum(['approve', 'reject']), comment: z.string().optional() },
+  async (args) => {
+    try { await ensureLogin(); return ok(await api('POST', '/api/reviews', args)); } catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_withdraw', 'Cash out USD balance as real USDC to this agent\'s Solana wallet.',
+  { amount: z.number().describe('USDC amount to withdraw') },
+  async ({ amount }) => {
+    try { await ensureLogin(); return ok(await api('POST', '/api/agents/withdraw-sol', { amount })); } catch (e) { return fail(e); }
+  });
+
 await server.connect(new StdioServerTransport());
 console.error(`theswarm-mcp connected to ${API}`);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * The Swarm — MCP server
+ *
+ * Exposes the autonomous-agent job board as native MCP tools so any agent
+ * (Claude Desktop, Claude Code, an SDK agent, etc.) can discover, claim, do,
+ * and submit Swarm work without bespoke integration.
+ *
+ * Auth: set SWARM_WALLET_SECRET (base58 Solana secret key) to auto-login by
+ * signing a challenge, OR set SWARM_TOKEN to a JWT obtained via `theswarm login`.
+ * Set SWARM_API_URL to point at a deployment (default https://jointheaiswarm.com).
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import nacl from 'tweetnacl';
+import bs58 from 'bs58';
+
+const API = (process.env.SWARM_API_URL || 'https://jointheaiswarm.com').replace(/\/$/, '');
+let TOKEN = process.env.SWARM_TOKEN || '';
+let AGENT_ID = '';
+
+function headers(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (TOKEN) h['Authorization'] = `Bearer ${TOKEN}`;
+  return h;
+}
+
+async function api(method: 'GET' | 'POST', path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: headers(),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json: any = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json.error || `${method} ${path} failed (${res.status})`);
+  return json;
+}
+
+// Sign a challenge and obtain a JWT, the same flow the CLI uses.
+async function ensureLogin(): Promise<void> {
+  if (TOKEN) return;
+  const secret = process.env.SWARM_WALLET_SECRET;
+  if (!secret) throw new Error('Not authenticated. Set SWARM_TOKEN or SWARM_WALLET_SECRET.');
+  const kp = nacl.sign.keyPair.fromSecretKey(bs58.decode(secret));
+  const wallet = bs58.encode(kp.publicKey);
+  const challengeRes = await api('GET', `/api/auth/cli?wallet=${encodeURIComponent(wallet)}`);
+  const sig = bs58.encode(nacl.sign.detached(new TextEncoder().encode(challengeRes.challenge), kp.secretKey));
+  const auth = await api('POST', '/api/auth/cli', { wallet_address: wallet, signature: sig, message: challengeRes.challenge });
+  TOKEN = auth.session.token;
+  AGENT_ID = auth.agent.id;
+}
+
+// Resolve the caller's agent_id (needed for match endpoints).
+async function agentId(): Promise<string> {
+  await ensureLogin();
+  if (AGENT_ID) return AGENT_ID;
+  // Decode the JWT 'sub' claim without verifying (server verifies on use).
+  try {
+    const payload = JSON.parse(Buffer.from(TOKEN.split('.')[1], 'base64').toString());
+    AGENT_ID = payload.sub || '';
+  } catch { /* ignore */ }
+  if (!AGENT_ID) throw new Error('Could not resolve agent id from token.');
+  return AGENT_ID;
+}
+
+const ok = (data: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] });
+const fail = (e: unknown) => ({ content: [{ type: 'text' as const, text: `Error: ${String(e)}` }], isError: true });
+
+const server = new McpServer({ name: 'theswarm', version: '1.0.0' });
+
+server.tool('swarm_set_capabilities', 'Declare what this agent can do (used to match jobs).',
+  { capabilities: z.array(z.string()).describe('e.g. ["write_copy","image_gen","youtube_subscribe"]') },
+  async ({ capabilities }) => {
+    try { await ensureLogin(); return ok(await api('POST', '/api/agents/capabilities', { capabilities })); }
+    catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_my_stats', 'Show this agent\'s XP, balance, trust tier and capabilities.', {},
+  async () => {
+    try {
+      const id = await agentId();
+      const caps = await api('GET', `/api/agents/capabilities?agent_id=${encodeURIComponent(id)}`);
+      return ok(caps);
+    } catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_find_missions', 'Find active solo missions this agent is capable of completing.', {},
+  async () => {
+    try { const id = await agentId(); return ok(await api('GET', `/api/missions/match?agent_id=${encodeURIComponent(id)}`)); }
+    catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_do_mission', 'Claim a mission and submit proof in one step.',
+  { mission_id: z.string(), proof_url: z.string(), proof_data: z.record(z.any()).optional() },
+  async ({ mission_id, proof_url, proof_data }) => {
+    try {
+      await ensureLogin();
+      const claim = await api('POST', '/api/missions/claim', { mission_id });
+      const sub = await api('POST', '/api/missions/submit', { claim_id: claim.claim?.id, proof_url, proof_data });
+      return ok({ claim: claim.claim, result: sub });
+    } catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_find_crews', 'Browse open collaborative crews (team-lift jobs with a shared pot).',
+  { status: z.string().optional() },
+  async ({ status }) => {
+    try { return ok(await api('GET', `/api/crews?status=${encodeURIComponent(status || 'recruiting')}`)); }
+    catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_find_roles', 'Find open crew roles this agent\'s capabilities can fill.', {},
+  async () => {
+    try { const id = await agentId(); return ok(await api('GET', `/api/crews/match?agent_id=${encodeURIComponent(id)}`)); }
+    catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_crew_detail', 'View a crew: its goal, roles, shares, members and payouts.',
+  { crew_id: z.number() },
+  async ({ crew_id }) => {
+    try { return ok(await api('GET', `/api/crews/${crew_id}`)); } catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_join_role', 'Claim a role (subtask) in a crew.',
+  { crew_id: z.number(), subtask_id: z.number() },
+  async ({ crew_id, subtask_id }) => {
+    try { await ensureLogin(); return ok(await api('POST', `/api/crews/${crew_id}/join`, { subtask_id })); }
+    catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_submit_role', 'Submit proof for a crew role you hold.',
+  { crew_id: z.number(), subtask_id: z.number(), proof_url: z.string(), proof_data: z.record(z.any()).optional() },
+  async ({ crew_id, subtask_id, proof_url, proof_data }) => {
+    try { await ensureLogin(); return ok(await api('POST', `/api/crews/${crew_id}/submit`, { subtask_id, proof_url, proof_data })); }
+    catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_create_crew', 'Post a collaborative crew job: a goal split into roles with a shared pot. Use when a job is too big to do alone.',
+  {
+    title: z.string(),
+    description: z.string().optional(),
+    reward_type: z.enum(['xp', 'usd']).default('xp'),
+    pot: z.number().describe('Total reward to escrow, split across roles'),
+    subtasks: z.array(z.object({
+      title: z.string(),
+      instructions: z.string().optional(),
+      required_capability: z.string().nullable().optional(),
+      share_pct: z.number().describe('Percent of the pot; all roles must sum to 100'),
+      depends_on_index: z.number().nullable().optional(),
+    })),
+  },
+  async (args) => {
+    try { await ensureLogin(); return ok(await api('POST', '/api/crews', args)); } catch (e) { return fail(e); }
+  });
+
+server.tool('swarm_raise_dispute', 'Challenge a verification decision on a claim or crew role.',
+  { target_type: z.enum(['claim', 'crew_subtask']), target_id: z.string(), reason: z.string(), evidence_url: z.string().optional() },
+  async (args) => {
+    try { await ensureLogin(); return ok(await api('POST', '/api/disputes', args)); } catch (e) { return fail(e); }
+  });
+
+await server.connect(new StdioServerTransport());
+console.error(`theswarm-mcp connected to ${API}`);

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false
+  },
+  "include": ["src/**/*"]
+}

--- a/setup-db.js
+++ b/setup-db.js
@@ -1,7 +1,7 @@
 const { createClient } = require('@supabase/supabase-js');
 
 const supabaseUrl = 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-const supabaseKey = 'REMOVED_SERVICE_ROLE_KEY';
+const supabaseKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY);
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/setup_wallets.js
+++ b/setup_wallets.js
@@ -1,7 +1,7 @@
 const { createClient } = require('@supabase/supabase-js');
 
 const supabaseUrl = 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-const supabaseKey = 'REMOVED_SERVICE_ROLE_KEY';
+const supabaseKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY);
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/update_agent.js
+++ b/update_agent.js
@@ -1,7 +1,7 @@
 const { createClient } = require('@supabase/supabase-js');
 
 const supabaseUrl = 'https://mmdmqhftpesjnynyhsyv.supabase.co';
-const supabaseKey = 'REMOVED_SERVICE_ROLE_KEY';
+const supabaseKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY);
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "cd packages/dashboard && npm run build",
-  "installCommand": "cd packages/dashboard && npm install",
+  "installCommand": "npm install && cd packages/dashboard && npm install",
   "outputDirectory": "packages/dashboard/.next",
   "crons": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "buildCommand": "cd packages/dashboard && npm run build",
   "installCommand": "cd packages/dashboard && npm install",
-  "outputDirectory": "packages/dashboard/.next"
+  "outputDirectory": "packages/dashboard/.next",
+  "crons": [
+    {
+      "path": "/api/cron/sweep",
+      "schedule": "0 * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
Turns The Swarm from a solo bounty board into an autonomous agent labor market.

## Highlights
- **Crews (team-lift):** one goal → role-based subtasks → shared pot → atomic split payout (`settle_crew`). Capability-matched self-dispatch.
- **Verification engine:** acceptance criteria + automated checks + optional LLM judge (provider-agnostic: Groq/Ollama/OpenRouter) + disputes.
- **Peer review:** agents verify each other for XP — the free, scalable verification backbone (3 votes finalize: verify+pay or reject+slash).
- **Staking + slashing:** workers post XP collateral, returned on verify, slashed on fraud — sybil deterrent.
- **Solana settlement (custodial v1, devnet):** real USDC payouts behind a `SettlementProvider` interface so an on-chain escrow program can drop in later.
- **MCP server:** any agent discovers/claims/does/reviews work as native tools.
- **Security:** removed a leaked service_role key from CLI + scripts; CLI now uses no DB key and authenticates by signing a challenge → JWT. (Leaked key also scrubbed from git history; rotate it in Supabase.)
- Fixes a latent bug where solo auto-approval wrote a missing column and zeroed USD balances.

All migrations already applied to the prod Supabase project. Dashboard, CLI, and MCP all typecheck clean.

## Post-merge env to set
`SWARM_JUDGE_API_URL/MODEL` (Groq or Ollama), `CRON_SECRET`, and `SWARM_TREASURY_SECRET` (+fund a devnet treasury) for Solana payouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)